### PR TITLE
Add script to build definitions if not found

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .snowpack
 build
 node_modules
+public/definitions

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "dev": "snowpack dev",
+    "dev": "node scripts/build-definitions.js && snowpack dev",
     "build": "via-keyboards public/definitions && snowpack build",
     "test": "web-test-runner \"src/**/*.test.tsx\"",
     "format": "prettier --write \"src/**/*.{js,jsx,ts,tsx}\"",

--- a/scripts/build-definitions.js
+++ b/scripts/build-definitions.js
@@ -1,0 +1,26 @@
+const fs = require('fs');
+const { exec } = require('child_process');
+
+function buildDefinitions() {
+  if (fs.existsSync('./public/definitions')) {
+    return;
+  }
+
+  console.log('Definitions not found. Building...');
+
+  exec('via-keyboards public/definitions', (error, stdout, stderr) => {
+    if (error) {
+      console.error(error);
+      return;
+    }
+     
+    if (stderr) {
+      console.error('stderr');
+      return;
+    }
+
+    console.log(stdout);
+  });
+}
+
+buildDefinitions();

--- a/snowpack.config.mjs
+++ b/snowpack.config.mjs
@@ -54,19 +54,6 @@ export default {
   routes: [
     /* Enable an SPA Fallback in development: */
     // {"match": "routes", "src": ".*", "dest": "/index.html"},
-    {
-      src: '/definitions/.*',
-      dest: (req, res) => {
-        console.log(req.url);
-        req.url = req.url.replace(/^\/definitions/, '');
-
-        console.log(req.url);
-        return proxy.web(req, res, {
-          hostname: 'localhost',
-          port: 5000,
-        });
-      },
-    },
   ],
   optimize: {
     /* Example: Bundle your final build: */


### PR DESCRIPTION
Adds a script to build definitions locally if they weren't found. This prevents the dev server from crashing when the `keyboards` repo isn't running locally.