### PR TITLE
Default to empty string if no parameters are passed in to LM or MT

### DIFF
--- a/src/utils/advanced-keys.ts
+++ b/src/utils/advanced-keys.ts
@@ -212,7 +212,7 @@ const topLevelModToString = (modNumber: number): string => {
 
 const parseTopLevelMacro = (inputParts: string[]): number => {
   const topLevelKey = inputParts[0];
-  const parameter = inputParts[1] || '';
+  const parameter = inputParts[1] ?? '';
   let [param1, param2] = ['', ''];
   let layer = 0;
   let mods = 0;
@@ -278,7 +278,7 @@ const parseTopLevelMacro = (inputParts: string[]): number => {
   }
 };
 
-const parseMods = (input: string): number => {
+const parseMods = (input: string = ''): number => {
   const parts = input.split('|').map((s) => s.trim());
   if (
     !parts.reduce((acc, part) => acc && modMasks.hasOwnProperty(part), true)


### PR DESCRIPTION
Fixes a crash when typing a multi-parameter macro like `LM` or `MT` into the `Any` keycode input.
