### PR TITLE
Added KC_PMNS to the list of autocomplete keycodes

### DIFF
--- a/src/utils/autocomplete-keycodes.ts
+++ b/src/utils/autocomplete-keycodes.ts
@@ -85,6 +85,7 @@ export const autocompleteKeycodes = {
   KC_KP_ASTERISK: true,
   KC_PAST: true,
   KC_PPLS: true,
+  KC_PMNS: true,
   KC_PENT: true,
   KC_P1: true,
   KC_P2: true,


### PR DESCRIPTION
This small change should fix #58 
It should also fix the-via/releases#25 which is where the issue was first mentioned
The changes were tested locally and I successfully created a macro with the keycode KC_PMNS 