### PR TITLE
Fix shifting legends on <KeyContainer>

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@types/lodash.partition": "^4.6.6",
         "@types/raf-schd": "^4.0.1",
         "@webscopeio/react-textarea-autocomplete": "^4.7.3",
+        "classnames": "^2.3.2",
         "downshift": "^6.1.7",
         "json-stringify-pretty-compact": "^3.0.0",
         "lodash.partition": "^4.6.0",
@@ -5956,6 +5957,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/classnames": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
+      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
     },
     "node_modules/clean-css": {
       "version": "4.2.4",
@@ -22822,6 +22828,11 @@
         "isobject": "^3.0.0",
         "static-extend": "^0.1.1"
       }
+    },
+    "classnames": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
+      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
     },
     "clean-css": {
       "version": "4.2.4",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@types/lodash.partition": "^4.6.6",
     "@types/raf-schd": "^4.0.1",
     "@webscopeio/react-textarea-autocomplete": "^4.7.3",
+    "classnames": "^2.3.2",
     "downshift": "^6.1.7",
     "json-stringify-pretty-compact": "^3.0.0",
     "lodash.partition": "^4.6.0",

--- a/src/app.global.css
+++ b/src/app.global.css
@@ -322,3 +322,26 @@ a:hover {
     stroke: var(--color_accent);
   }
 }
+
+/* Bugfix for shifting animations on keys */
+.key-container {
+  animation-direction: alternate;
+  animation-duration: 0s;
+  animation-iteration-count: infinite;
+  animation-name: select-glow;
+  animation-timing-function: ease-in-out;
+  box-sizing: border-box;
+  position: absolute;
+  transition: transform 0.2s ease-out;
+  user-select: none;
+}
+
+.key-container:hover  {
+  transform: translate3d(0, -4px, 0);
+}
+
+.key-container.key-selected {
+  animation-duration: 1.5s;
+  transform: translate3d(0, -4px, 0) scale(0.99);
+}
+

--- a/src/components/positioned-keyboard/base.tsx
+++ b/src/components/positioned-keyboard/base.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import classNames from 'classnames';
+import React, { HTMLProps } from 'react';
 import styled from 'styled-components';
 
 type KeyRotation = {
@@ -74,27 +75,19 @@ export const RotationContainer = styled.div<{
   ${(props) => (props.selected ? 'z-index:2;' : '')}
 `;
 
-export const KeyContainer = styled.div<{selected: boolean}>`
-  position: absolute;
-  box-sizing: border-box;
-  transition: transform 0.2s ease-out;
-  user-select: none;
-  transform: ${(props) =>
-    props.selected
-      ? 'translate3d(0, -4px, 0) scale(0.99)'
-      : 'translate3d(0,0,0)'};
-  :hover {
-    transform: ${(props) =>
-      props.selected
-        ? 'translate3d(0, -4px, 0) scale(0.99)'
-        : 'translate3d(0,-4px,0)'};
-  }
-  animation-name: select-glow;
-  animation-duration: ${(props) => (props.selected ? 1.5 : 0)}s;
-  animation-iteration-count: infinite;
-  animation-direction: alternate;
-  animation-timing-function: ease-in-out;
-`;
+export function KeyContainer({
+  className,
+  selected,
+  ...divProps
+}: { selected: boolean } & HTMLProps<HTMLDivElement>) {
+  const divClassName = classNames('key-container', className, {
+    'key-selected': selected
+  });
+
+  return (
+    <div className={divClassName} {...divProps} />
+  );
+}
 
 export const Legend = styled.div`
   font-family: Arial, Helvetica, sans-serif;


### PR DESCRIPTION
Something about the styled-components injected CSS was causing an issue in Chrome.

<table>
  <thead>
    <tr>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>
<img src="https://user-images.githubusercontent.com/194567/206919100-d0ae1a87-0a62-460e-b8df-b4d478168f65.gif" />
</td>
      <td>
<img src="https://user-images.githubusercontent.com/194567/206919126-592f0363-7272-441e-8983-ebc24158f587.gif" />
</td>
    </tr>
  </tbody>
</table>
