### PR TITLE
Fix macros with keycodes containing digits

### DIFF
--- a/src/utils/macro-api/index.ts
+++ b/src/utils/macro-api/index.ts
@@ -5,10 +5,11 @@ import {MacroAPI, MacroValidator, validateMacroExpression} from './macro-api';
 import {MacroAPIV11, validateMacroExpressionV11} from './macro-api.v11';
 
 export const getMacroAPI = (protocol: number, keyboardApi: KeyboardAPI) => {
+  const basicKeyToByte = getBasicKeyDict(protocol);
   const byteToKey = getByteToKey(getBasicKeyDict(protocol));
   return protocol >= 11
-    ? new MacroAPIV11(keyboardApi, byteToKey)
-    : new MacroAPI(keyboardApi, byteToKey);
+    ? new MacroAPIV11(keyboardApi, basicKeyToByte, byteToKey)
+    : new MacroAPI(keyboardApi, basicKeyToByte, byteToKey);
 };
 
 export const getMacroValidator = (protocol: number): MacroValidator =>

--- a/src/utils/macro-api/macro-api.common.ts
+++ b/src/utils/macro-api/macro-api.common.ts
@@ -1,5 +1,3 @@
-import basicKeyToByte from '../key-to-byte/default.json5';
-
 export type ValidationResult = {
   isValid: boolean;
   errorMessage?: string;
@@ -22,10 +20,10 @@ export const KeyActionPrefix = 1; // \x01
 export const DelayTerminator = 124; // '|';
 export const MacroTerminator = 0;
 
-export function getByte(keycode: string): number {
+export function getByte(basicKeyToByte: Record<string, number>, keycode: string): number {
   return basicKeyToByte[keycode.toUpperCase()];
 }
 
-export function buildKeyActionBytes(keyaction: KeyAction, keycode: string) {
-  return [KeyActionPrefix, keyaction, getByte(keycode)];
+export function buildKeyActionBytes(basicKeyToByte: Record<string, number>, keyaction: KeyAction, keycode: string) {
+  return [KeyActionPrefix, keyaction, getByte(basicKeyToByte, keycode)];
 }

--- a/src/utils/macro-api/macro-api.ts
+++ b/src/utils/macro-api/macro-api.ts
@@ -73,6 +73,7 @@ export function validateMacroExpression(expression: string): ValidationResult {
 export class MacroAPI implements IMacroAPI {
   constructor(
     private keyboardApi: KeyboardAPI,
+    private basicKeyToByte: Record<string, number>,
     private byteToKey: Record<number, string>,
   ) {}
 
@@ -161,18 +162,18 @@ export class MacroAPI implements IMacroAPI {
               );
             case 1:
               bytes.push(KeyAction.Tap);
-              bytes.push(getByte(keycodes[0]));
+              bytes.push(getByte(this.basicKeyToByte, keycodes[0]));
               break;
             default:
               // Keydowns
               keycodes.forEach((keycode) => {
                 bytes.push(KeyAction.Down);
-                bytes.push(getByte(keycode));
+                bytes.push(getByte(this.basicKeyToByte, keycode));
               });
               // Symmetrical Keyups
               keycodes.reverse().forEach((keycode) => {
                 bytes.push(KeyAction.Up);
-                bytes.push(getByte(keycode));
+                bytes.push(getByte(this.basicKeyToByte, keycode));
               });
               break;
           }

--- a/src/utils/macro-api/macro-api.v11.ts
+++ b/src/utils/macro-api/macro-api.v11.ts
@@ -86,6 +86,7 @@ export function validateMacroExpressionV11(
 export class MacroAPIV11 implements IMacroAPI {
   constructor(
     private keyboardApi: KeyboardAPI,
+    private basicKeyToByte: Record<string, number>,
     private byteToKey: Record<number, string>,
   ) {}
 
@@ -188,7 +189,7 @@ export class MacroAPIV11 implements IMacroAPI {
           }
           const block = expression.substr(i + 1, keyActionEnd - i - 1);
           // If it's a delay value
-          if (/\d+/.test(block)) {
+          if (/^\d+$/.test(block)) {
             bytes.push(
               KeyActionPrefix,
               KeyAction.Delay,
@@ -207,16 +208,16 @@ export class MacroAPIV11 implements IMacroAPI {
                   'Syntax error: Keycodes expected within block. Use \\{} to define literal {}',
                 );
               case 1:
-                bytes.push(...buildKeyActionBytes(KeyAction.Tap, keycodes[0]));
+                bytes.push(...buildKeyActionBytes(this.basicKeyToByte, KeyAction.Tap, keycodes[0]));
                 break;
               default:
                 // Keydowns
                 keycodes.forEach((keycode) => {
-                  bytes.push(...buildKeyActionBytes(KeyAction.Down, keycode));
+                  bytes.push(...buildKeyActionBytes(this.basicKeyToByte, KeyAction.Down, keycode));
                 });
                 // Symmetrical Keyups
                 keycodes.reverse().forEach((keycode) => {
-                  bytes.push(...buildKeyActionBytes(KeyAction.Up, keycode));
+                  bytes.push(...buildKeyActionBytes(this.basicKeyToByte, KeyAction.Up, keycode));
                 });
                 break;
             }


### PR DESCRIPTION
Slight bug added when we added delays in macros, which would convert `{100}` into a delay, parsing of the number would catch `KC_1`, `KC_F4`, etc. and do wrong things.

Also refactored keycode to byte lookups to be versioned like elsewhere.