### PR TITLE
Fix keycode/range custom controls to use 16-bit values

### DIFF
--- a/src/components/panes/configure-panes/custom/custom-control.tsx
+++ b/src/components/panes/configure-panes/custom/custom-control.tsx
@@ -60,7 +60,6 @@ const valueIsChecked = (option: number | number[], value: number[]) =>
   boxOrArr(option).every((o, i) => o == value[i]);
 
 const getRangeValue = (value: number[], max: number) => {
-  debugger;
   if (max > 255) {
     return shiftTo16Bit([value[0], value[1]]);
   } else {
@@ -69,7 +68,6 @@ const getRangeValue = (value: number[], max: number) => {
 };
 
 const getRangeBytes = (value: number, max: number) => {
-  debugger;
   if (max > 255) {
     return shiftFrom16Bit(value);
   } else {

--- a/src/components/panes/configure-panes/custom/custom-control.tsx
+++ b/src/components/panes/configure-panes/custom/custom-control.tsx
@@ -12,13 +12,7 @@ import type {
 } from '@the-via/reader';
 import type {LightingData} from '../../../../types/types';
 import {ArrayColorPicker} from '../../../inputs/color-picker';
-
-const shiftTo16Bit = ([hi, lo]: [number, number]): number => (hi << 8) | lo;
-
-const shiftFrom16Bit = (value: number): [number, number] => [
-  value >> 8,
-  value & 255,
-];
+import { shiftFrom16Bit, shiftTo16Bit } from 'src/utils/keyboard-api';
 
 type Props = {
   lightingData: LightingData;

--- a/src/components/panes/configure-panes/custom/custom-control.tsx
+++ b/src/components/panes/configure-panes/custom/custom-control.tsx
@@ -12,7 +12,7 @@ import type {
 } from '@the-via/reader';
 import type {LightingData} from '../../../../types/types';
 import {ArrayColorPicker} from '../../../inputs/color-picker';
-import { shiftFrom16Bit, shiftTo16Bit } from 'src/utils/keyboard-api';
+import {shiftFrom16Bit, shiftTo16Bit} from 'src/utils/keyboard-api';
 
 type Props = {
   lightingData: LightingData;
@@ -59,6 +59,24 @@ const boxOrArr = <N extends any>(elem: N | N[]) =>
 const valueIsChecked = (option: number | number[], value: number[]) =>
   boxOrArr(option).every((o, i) => o == value[i]);
 
+const getRangeValue = (value: number[], max: number) => {
+  debugger;
+  if (max > 255) {
+    return shiftTo16Bit([value[0], value[1]]);
+  } else {
+    return value[0];
+  }
+};
+
+const getRangeBytes = (value: number, max: number) => {
+  debugger;
+  if (max > 255) {
+    return shiftFrom16Bit(value);
+  } else {
+    return [value];
+  }
+};
+
 export const VIACustomControl = (props: VIACustomControlProps) => {
   const {content, type, options, value} = props as any;
   const [name, ...command] = content;
@@ -68,8 +86,14 @@ export const VIACustomControl = (props: VIACustomControlProps) => {
         <AccentRange
           min={options[0]}
           max={options[1]}
-          defaultValue={props.value[0]}
-          onChange={(val: number) => props.updateValue(name, ...command, val)}
+          defaultValue={getRangeValue(props.value, options[1])}
+          onChange={(val: number) =>
+            props.updateValue(
+              name,
+              ...command,
+              ...getRangeBytes(val, options[1]),
+            )
+          }
         />
       );
     }
@@ -78,7 +102,9 @@ export const VIACustomControl = (props: VIACustomControlProps) => {
         <PelpiKeycodeInput
           value={shiftTo16Bit([props.value[0], props.value[1]])}
           meta={{}}
-          setValue={(val: number) => props.updateValue(name, ...command, ...shiftFrom16Bit(val))}
+          setValue={(val: number) =>
+            props.updateValue(name, ...command, ...shiftFrom16Bit(val))
+          }
         />
       );
     }

--- a/src/components/panes/configure-panes/custom/custom-control.tsx
+++ b/src/components/panes/configure-panes/custom/custom-control.tsx
@@ -13,6 +13,13 @@ import type {
 import type {LightingData} from '../../../../types/types';
 import {ArrayColorPicker} from '../../../inputs/color-picker';
 
+const shiftTo16Bit = ([hi, lo]: [number, number]): number => (hi << 8) | lo;
+
+const shiftFrom16Bit = (value: number): [number, number] => [
+  value >> 8,
+  value & 255,
+];
+
 type Props = {
   lightingData: LightingData;
   definition: VIADefinitionV2 | VIADefinitionV3;
@@ -75,9 +82,9 @@ export const VIACustomControl = (props: VIACustomControlProps) => {
     case 'keycode': {
       return (
         <PelpiKeycodeInput
-          value={props.value[0]}
+          value={shiftTo16Bit([props.value[0], props.value[1]])}
           meta={{}}
-          setValue={(val: number) => props.updateValue(name, ...command, val)}
+          setValue={(val: number) => props.updateValue(name, ...command, ...shiftFrom16Bit(val))}
         />
       );
     }

--- a/src/utils/keyboard-api.ts
+++ b/src/utils/keyboard-api.ts
@@ -85,9 +85,9 @@ const eqArr = <T>(arr1: T[], arr2: T[]) => {
   return arr1.every((val, idx) => arr2[idx] === val);
 };
 
-const shiftTo16Bit = ([hi, lo]: [number, number]): number => (hi << 8) | lo;
+export const shiftTo16Bit = ([hi, lo]: [number, number]): number => (hi << 8) | lo;
 
-const shiftFrom16Bit = (value: number): [number, number] => [
+export const shiftFrom16Bit = (value: number): [number, number] => [
   value >> 8,
   value & 255,
 ];


### PR DESCRIPTION
Custom menu keycode control is only loading/saving one byte, should be two bytes.