### PR TITLE
Expand key label on hover

### DIFF
--- a/src/components/positioned-keyboard/base.tsx
+++ b/src/components/positioned-keyboard/base.tsx
@@ -103,6 +103,11 @@ export const Legend = styled.div`
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  &:hover {
+    white-space: normal;
+    overflow: visible;
+    text-overflow: unset;
+  }
 `;
 
 export const getLegends = (


### PR DESCRIPTION
In #105, the user would like some indication of the full label of the key without having to check the source code.

I implemented the hover for the label component, so when a user hovers on a label, it shows the full label not cropped.
This won't change the behaviour of labels that are not cropped. Some screenshots to illustrate:

Hovering on the RGB control keys display the full label. Selecting the key brings the full label to the foreground.
Selecting without hovering over the label does not show the full label.

Let me know what you think

<img width="1095" alt="Screen Shot 2023-02-03 at 1 14 59 PM" src="https://user-images.githubusercontent.com/39207554/216678217-a8142dff-f244-455a-ab56-81c2fcd5ccd3.png">
<img width="1095" alt="Screen Shot 2023-02-03 at 1 15 07 PM" src="https://user-images.githubusercontent.com/39207554/216678218-1e7e7f22-2815-41db-b74e-d09c8e6441c9.png">
<img width="1095" alt="Screen Shot 2023-02-03 at 1 15 14 PM" src="https://user-images.githubusercontent.com/39207554/216678222-0e8ec775-0dd6-43ba-8517-918645fb3711.png">

