### PR TITLE
Avoid non-serialisable data in store

### DIFF
--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -157,7 +157,7 @@ export const Home: React.VFC<HomeProps> = (props) => {
     if (!selectedDevice) {
       return;
     }
-    const api = new KeyboardAPI(selectedDevice.device);
+    const api = new KeyboardAPI(selectedDevice.path);
 
     // TODO: Some sort of toggling lights on v3 firmware
     if (!isVIADefinitionV2(selectedDefinition)) {

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -31,6 +31,7 @@ import {
 import {getNextKey} from 'src/utils/keyboard-rendering';
 import {mapEvtToKeycode} from 'src/utils/key-event';
 import {OVERRIDE_HID_CHECK} from 'src/utils/override';
+import {KeyboardAPI} from 'src/utils/keyboard-api';
 
 const ErrorHome = styled.div`
   background: var(--bg_gradient);
@@ -156,7 +157,7 @@ export const Home: React.VFC<HomeProps> = (props) => {
     if (!selectedDevice) {
       return;
     }
-    const {api} = selectedDevice;
+    const api = new KeyboardAPI(selectedDevice.device);
 
     // TODO: Some sort of toggling lights on v3 firmware
     if (!isVIADefinitionV2(selectedDefinition)) {

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -9,7 +9,7 @@ import {
 } from '@the-via/reader';
 import {
   getSelectedConnectedDevice,
-  getSelectedKeyboardApi,
+  getSelectedKeyboardAPI,
 } from 'src/store/devicesSlice';
 import {
   loadSupportedIds,
@@ -99,13 +99,12 @@ export const Home: React.VFC<HomeProps> = (props) => {
     getAllowKeyboardKeyRemapping,
   );
   const selectedKey = useAppSelector(getSelectedKey);
-  const selectedDevice = useAppSelector(getSelectedConnectedDevice);
   const selectedDefinition = useAppSelector(getSelectedDefinition);
   const selectedLayerIndex = useAppSelector(getSelectedLayerIndex);
   const selectedKeyDefinitions = useAppSelector(getSelectedKeyDefinitions);
   const disableFastRemap = useAppSelector(getDisableFastRemap);
   const {basicKeyToByte} = useAppSelector(getBasicKeyToByte);
-  const api = useAppSelector(getSelectedKeyboardApi);
+  const api = useAppSelector(getSelectedKeyboardAPI);
 
   const updateDevicesRepeat: () => void = timeoutRepeater(
     () => {
@@ -157,7 +156,7 @@ export const Home: React.VFC<HomeProps> = (props) => {
   };
 
   const toggleLights = async () => {
-    if (!selectedDevice) {
+    if (!api) {
       return;
     }
 
@@ -215,7 +214,7 @@ export const Home: React.VFC<HomeProps> = (props) => {
   useEffect(() => {
     dispatch(updateSelectedKeyAction(null));
     toggleLights();
-  }, [selectedDevice]);
+  }, [api]);
 
   return !hasHIDSupport && !OVERRIDE_HID_CHECK ? (
     <ErrorHome ref={homeElem} tabIndex={0}>

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -7,7 +7,10 @@ import {
   isVIADefinitionV2,
   LightingValue,
 } from '@the-via/reader';
-import {getSelectedConnectedDevice} from 'src/store/devicesSlice';
+import {
+  getSelectedConnectedDevice,
+  getSelectedKeyboardApi,
+} from 'src/store/devicesSlice';
 import {
   loadSupportedIds,
   reloadConnectedDevices,
@@ -31,7 +34,6 @@ import {
 import {getNextKey} from 'src/utils/keyboard-rendering';
 import {mapEvtToKeycode} from 'src/utils/key-event';
 import {OVERRIDE_HID_CHECK} from 'src/utils/override';
-import {KeyboardAPI} from 'src/utils/keyboard-api';
 
 const ErrorHome = styled.div`
   background: var(--bg_gradient);
@@ -103,6 +105,7 @@ export const Home: React.VFC<HomeProps> = (props) => {
   const selectedKeyDefinitions = useAppSelector(getSelectedKeyDefinitions);
   const disableFastRemap = useAppSelector(getDisableFastRemap);
   const {basicKeyToByte} = useAppSelector(getBasicKeyToByte);
+  const api = useAppSelector(getSelectedKeyboardApi);
 
   const updateDevicesRepeat: () => void = timeoutRepeater(
     () => {
@@ -157,7 +160,6 @@ export const Home: React.VFC<HomeProps> = (props) => {
     if (!selectedDevice) {
       return;
     }
-    const api = new KeyboardAPI(selectedDevice.path);
 
     // TODO: Some sort of toggling lights on v3 firmware
     if (!isVIADefinitionV2(selectedDefinition)) {

--- a/src/components/panes/configure-panes/custom/satisfaction75/api.ts
+++ b/src/components/panes/configure-panes/custom/satisfaction75/api.ts
@@ -1,3 +1,4 @@
+import {EncoderBehavior} from 'src/types/types';
 import type {KeyboardAPI} from '../../../../../utils/keyboard-api';
 
 const GET_KEYBOARD_VALUE = 0x02;
@@ -52,7 +53,7 @@ export const setOLEDMode = async (api: KeyboardAPI, newDefaultMode: number) => {
 export const getCustomEncoderConfig = async (
   api: KeyboardAPI,
   encoderIdx: number,
-) => {
+): Promise<EncoderBehavior> => {
   const bytes = [KB_VALUES.ENCODER_CUSTOM, encoderIdx];
   const raw = await api.hidCommand(GET_KEYBOARD_VALUE, bytes);
   const [, , , cw1, cw2, ccw1, ccw2, press1, press2] = raw;

--- a/src/components/panes/configure-panes/custom/satisfaction75/menu.tsx
+++ b/src/components/panes/configure-panes/custom/satisfaction75/menu.tsx
@@ -13,7 +13,7 @@ import {
 } from './api';
 import {EncoderModeToggle} from './encoder-mode-toggle';
 import {EncoderCustomConfig} from './encoder-custom-config';
-import type {KeyboardAPI} from '../../../../../utils/keyboard-api';
+import {KeyboardAPI} from '../../../../../utils/keyboard-api';
 import {getSelectedConnectedDevice} from 'src/store/devicesSlice';
 import {useAppSelector} from 'src/store/hooks';
 
@@ -74,10 +74,12 @@ type State = {
   encoderBehaviors: EncoderBehavior[];
 };
 
+// TODO: Can we get rid of SatisfactionMenu now that we have v3 definitions?
 export const SatisfactionMenu = () => {
   const selectedDevice = useAppSelector(getSelectedConnectedDevice);
   if (selectedDevice) {
-    return <BaseSatisfactionMenu api={selectedDevice.api} />;
+    const api = new KeyboardAPI(selectedDevice.device);
+    return <BaseSatisfactionMenu api={api} />;
   }
   return null;
 };

--- a/src/components/panes/configure-panes/custom/satisfaction75/menu.tsx
+++ b/src/components/panes/configure-panes/custom/satisfaction75/menu.tsx
@@ -14,7 +14,7 @@ import {
 import {EncoderModeToggle} from './encoder-mode-toggle';
 import {EncoderCustomConfig} from './encoder-custom-config';
 import {KeyboardAPI} from '../../../../../utils/keyboard-api';
-import {getSelectedKeyboardApi} from 'src/store/devicesSlice';
+import {getSelectedKeyboardAPI} from 'src/store/devicesSlice';
 import {useAppSelector} from 'src/store/hooks';
 import {EncoderBehavior} from 'src/types/types';
 
@@ -76,7 +76,7 @@ type State = {
 
 // TODO: Can we get rid of SatisfactionMenu now that we have v3 definitions?
 export const SatisfactionMenu = () => {
-  const api = useAppSelector(getSelectedKeyboardApi);
+  const api = useAppSelector(getSelectedKeyboardAPI);
   if (api) {
     return <BaseSatisfactionMenu api={api} />;
   }

--- a/src/components/panes/configure-panes/custom/satisfaction75/menu.tsx
+++ b/src/components/panes/configure-panes/custom/satisfaction75/menu.tsx
@@ -78,7 +78,7 @@ type State = {
 export const SatisfactionMenu = () => {
   const selectedDevice = useAppSelector(getSelectedConnectedDevice);
   if (selectedDevice) {
-    const api = new KeyboardAPI(selectedDevice.device);
+    const api = new KeyboardAPI(selectedDevice.path);
     return <BaseSatisfactionMenu api={api} />;
   }
   return null;

--- a/src/components/panes/configure-panes/custom/satisfaction75/menu.tsx
+++ b/src/components/panes/configure-panes/custom/satisfaction75/menu.tsx
@@ -14,7 +14,7 @@ import {
 import {EncoderModeToggle} from './encoder-mode-toggle';
 import {EncoderCustomConfig} from './encoder-custom-config';
 import {KeyboardAPI} from '../../../../../utils/keyboard-api';
-import {getSelectedConnectedDevice} from 'src/store/devicesSlice';
+import {getSelectedKeyboardApi} from 'src/store/devicesSlice';
 import {useAppSelector} from 'src/store/hooks';
 import {EncoderBehavior} from 'src/types/types';
 
@@ -76,9 +76,8 @@ type State = {
 
 // TODO: Can we get rid of SatisfactionMenu now that we have v3 definitions?
 export const SatisfactionMenu = () => {
-  const selectedDevice = useAppSelector(getSelectedConnectedDevice);
-  if (selectedDevice) {
-    const api = new KeyboardAPI(selectedDevice.path);
+  const api = useAppSelector(getSelectedKeyboardApi);
+  if (api) {
     return <BaseSatisfactionMenu api={api} />;
   }
   return null;

--- a/src/components/panes/configure-panes/custom/satisfaction75/menu.tsx
+++ b/src/components/panes/configure-panes/custom/satisfaction75/menu.tsx
@@ -16,10 +16,10 @@ import {EncoderCustomConfig} from './encoder-custom-config';
 import {KeyboardAPI} from '../../../../../utils/keyboard-api';
 import {getSelectedConnectedDevice} from 'src/store/devicesSlice';
 import {useAppSelector} from 'src/store/hooks';
+import {EncoderBehavior} from 'src/types/types';
 
 type EnabledEncoderModes = number;
 type OLEDMode = number;
-type EncoderBehavior = [number, number, number];
 
 const MenuContainer = styled.div`
   display: flex;
@@ -119,10 +119,14 @@ class BaseSatisfactionMenu extends Component<{api: KeyboardAPI}, State> {
       encoder2,
     ] = await Promise.all(promises);
     this.setState({
-      enabledModes,
-      defaultOLEDMode,
-      currOLEDMode,
-      encoderBehaviors: [encoder0, encoder1, encoder2],
+      enabledModes: enabledModes as number,
+      defaultOLEDMode: defaultOLEDMode as number,
+      currOLEDMode: currOLEDMode as number,
+      encoderBehaviors: [
+        encoder0 as EncoderBehavior,
+        encoder1 as EncoderBehavior,
+        encoder2 as EncoderBehavior,
+      ],
     });
   };
 

--- a/src/components/panes/configure-panes/encoder.tsx
+++ b/src/components/panes/configure-panes/encoder.tsx
@@ -14,7 +14,7 @@ import {
 import type {VIAKey} from '@the-via/reader';
 import {
   getSelectedConnectedDevice,
-  getSelectedKeyboardApi,
+  getSelectedKeyboardAPI,
 } from 'src/store/devicesSlice';
 import {KeyboardAPI} from 'src/utils/keyboard-api';
 
@@ -49,7 +49,7 @@ export const Pane: FC = () => {
   const encoderKey = keys[selectedKey];
   const canClick = encoderKey.col !== -1 && encoderKey.row !== -1;
   const selectedDevice = useAppSelector(getSelectedConnectedDevice);
-  const api = useAppSelector(getSelectedKeyboardApi);
+  const api = useAppSelector(getSelectedKeyboardAPI);
 
   const setEncoderValue = (type: 'ccw' | 'cw' | 'click', val: number) => {
     if (api && encoderKey.ei !== undefined) {

--- a/src/components/panes/configure-panes/encoder.tsx
+++ b/src/components/panes/configure-panes/encoder.tsx
@@ -47,12 +47,8 @@ export const Pane: FC = () => {
   const canClick = encoderKey.col !== -1 && encoderKey.row !== -1;
   const selectedDevice = useAppSelector(getSelectedConnectedDevice);
   const setEncoderValue = (type: 'ccw' | 'cw' | 'click', val: number) => {
-    if (
-      selectedDevice &&
-      selectedDevice.device &&
-      encoderKey.ei !== undefined
-    ) {
-      const api = new KeyboardAPI(selectedDevice.device);
+    if (selectedDevice && selectedDevice.path && encoderKey.ei !== undefined) {
+      const api = new KeyboardAPI(selectedDevice.path);
       const encoderId = +encoderKey.ei;
       switch (type) {
         case 'ccw': {
@@ -83,10 +79,10 @@ export const Pane: FC = () => {
       encoderKey !== undefined &&
       encoderKey.ei !== undefined &&
       selectedDevice &&
-      selectedDevice.device
+      selectedDevice.path
     ) {
       const encoderId = +encoderKey.ei;
-      const api = new KeyboardAPI(selectedDevice.device);
+      const api = new KeyboardAPI(selectedDevice.path);
       loadValues(layer, encoderId, api);
     }
   }, [encoderKey, selectedDevice, layer]);

--- a/src/components/panes/configure-panes/encoder.tsx
+++ b/src/components/panes/configure-panes/encoder.tsx
@@ -13,7 +13,7 @@ import {
 } from 'src/store/keymapSlice';
 import type {VIAKey} from '@the-via/reader';
 import {getSelectedConnectedDevice} from 'src/store/devicesSlice';
-import type {KeyboardAPI} from 'src/utils/keyboard-api';
+import {KeyboardAPI} from 'src/utils/keyboard-api';
 
 const Encoder = styled(CenterPane)`
   height: 100%;
@@ -47,8 +47,12 @@ export const Pane: FC = () => {
   const canClick = encoderKey.col !== -1 && encoderKey.row !== -1;
   const selectedDevice = useAppSelector(getSelectedConnectedDevice);
   const setEncoderValue = (type: 'ccw' | 'cw' | 'click', val: number) => {
-    if (selectedDevice && selectedDevice.api && encoderKey.ei !== undefined) {
-      const {api} = selectedDevice;
+    if (
+      selectedDevice &&
+      selectedDevice.device &&
+      encoderKey.ei !== undefined
+    ) {
+      const api = new KeyboardAPI(selectedDevice.device);
       const encoderId = +encoderKey.ei;
       switch (type) {
         case 'ccw': {
@@ -79,10 +83,11 @@ export const Pane: FC = () => {
       encoderKey !== undefined &&
       encoderKey.ei !== undefined &&
       selectedDevice &&
-      selectedDevice.api
+      selectedDevice.device
     ) {
       const encoderId = +encoderKey.ei;
-      loadValues(layer, encoderId, selectedDevice.api);
+      const api = new KeyboardAPI(selectedDevice.device);
+      loadValues(layer, encoderId, api);
     }
   }, [encoderKey, selectedDevice, layer]);
 

--- a/src/components/panes/configure-panes/encoder.tsx
+++ b/src/components/panes/configure-panes/encoder.tsx
@@ -12,7 +12,10 @@ import {
   updateKey,
 } from 'src/store/keymapSlice';
 import type {VIAKey} from '@the-via/reader';
-import {getSelectedConnectedDevice} from 'src/store/devicesSlice';
+import {
+  getSelectedConnectedDevice,
+  getSelectedKeyboardApi,
+} from 'src/store/devicesSlice';
 import {KeyboardAPI} from 'src/utils/keyboard-api';
 
 const Encoder = styled(CenterPane)`
@@ -46,9 +49,10 @@ export const Pane: FC = () => {
   const encoderKey = keys[selectedKey];
   const canClick = encoderKey.col !== -1 && encoderKey.row !== -1;
   const selectedDevice = useAppSelector(getSelectedConnectedDevice);
+  const api = useAppSelector(getSelectedKeyboardApi);
+
   const setEncoderValue = (type: 'ccw' | 'cw' | 'click', val: number) => {
-    if (selectedDevice && selectedDevice.path && encoderKey.ei !== undefined) {
-      const api = new KeyboardAPI(selectedDevice.path);
+    if (api && encoderKey.ei !== undefined) {
       const encoderId = +encoderKey.ei;
       switch (type) {
         case 'ccw': {
@@ -75,14 +79,8 @@ export const Pane: FC = () => {
     setCCWValue(ccw);
   };
   useEffect(() => {
-    if (
-      encoderKey !== undefined &&
-      encoderKey.ei !== undefined &&
-      selectedDevice &&
-      selectedDevice.path
-    ) {
+    if (encoderKey !== undefined && encoderKey.ei !== undefined && api) {
       const encoderId = +encoderKey.ei;
-      const api = new KeyboardAPI(selectedDevice.path);
       loadValues(layer, encoderId, api);
     }
   }, [encoderKey, selectedDevice, layer]);

--- a/src/components/panes/configure-panes/save-load.tsx
+++ b/src/components/panes/configure-panes/save-load.tsx
@@ -18,9 +18,11 @@ import {
   saveRawKeymapToDevice,
 } from 'src/store/keymapSlice';
 import {useAppDispatch, useAppSelector} from 'src/store/hooks';
-import {getSelectedConnectedDevice} from 'src/store/devicesSlice';
+import {
+  getSelectedConnectedDevice,
+  getSelectedKeyboardApi,
+} from 'src/store/devicesSlice';
 import {getExpressions, saveMacros} from 'src/store/macrosSlice';
-import {KeyboardAPI} from 'src/utils/keyboard-api';
 
 type ViaSaveFile = {
   name: string;
@@ -49,13 +51,14 @@ export const Pane: FC = () => {
   const dispatch = useAppDispatch();
   const selectedDefinition = useAppSelector(getSelectedDefinition);
   const selectedDevice = useAppSelector(getSelectedConnectedDevice);
+  const api = useAppSelector(getSelectedKeyboardApi);
   const rawLayers = useAppSelector(getSelectedRawLayers);
   const macros = useAppSelector((state) => state.macros);
   const expressions = useAppSelector(getExpressions);
   const {basicKeyToByte, byteToKey} = useAppSelector(getBasicKeyToByte);
 
   // TODO: improve typing so we can remove this
-  if (!selectedDefinition || !selectedDevice) {
+  if (!selectedDefinition || !selectedDevice || !api) {
     return null;
   }
 
@@ -76,7 +79,6 @@ export const Pane: FC = () => {
     if (encoders.length > 0) {
       const maxEncoder = Math.max(...encoders) + 1;
       const numberOfLayers = rawLayers.length;
-      const api = new KeyboardAPI(selectedDevice.path);
       const encoderValues = await Promise.all(
         Array(maxEncoder)
           .fill(0)
@@ -202,7 +204,6 @@ export const Pane: FC = () => {
 
       await dispatch(saveRawKeymapToDevice(keymap, selectedDevice));
 
-      const api = new KeyboardAPI(selectedDevice.path);
       if (saveFile.encoders) {
         await Promise.all(
           saveFile.encoders.map((encoder, id) =>

--- a/src/components/panes/configure-panes/save-load.tsx
+++ b/src/components/panes/configure-panes/save-load.tsx
@@ -76,7 +76,7 @@ export const Pane: FC = () => {
     if (encoders.length > 0) {
       const maxEncoder = Math.max(...encoders) + 1;
       const numberOfLayers = rawLayers.length;
-      const api = new KeyboardAPI(selectedDevice.device);
+      const api = new KeyboardAPI(selectedDevice.path);
       const encoderValues = await Promise.all(
         Array(maxEncoder)
           .fill(0)
@@ -202,7 +202,7 @@ export const Pane: FC = () => {
 
       await dispatch(saveRawKeymapToDevice(keymap, selectedDevice));
 
-      const api = new KeyboardAPI(selectedDevice.device);
+      const api = new KeyboardAPI(selectedDevice.path);
       if (saveFile.encoders) {
         await Promise.all(
           saveFile.encoders.map((encoder, id) =>

--- a/src/components/panes/configure-panes/save-load.tsx
+++ b/src/components/panes/configure-panes/save-load.tsx
@@ -20,6 +20,7 @@ import {
 import {useAppDispatch, useAppSelector} from 'src/store/hooks';
 import {getSelectedConnectedDevice} from 'src/store/devicesSlice';
 import {getExpressions, saveMacros} from 'src/store/macrosSlice';
+import {KeyboardAPI} from 'src/utils/keyboard-api';
 
 type ViaSaveFile = {
   name: string;
@@ -75,6 +76,7 @@ export const Pane: FC = () => {
     if (encoders.length > 0) {
       const maxEncoder = Math.max(...encoders) + 1;
       const numberOfLayers = rawLayers.length;
+      const api = new KeyboardAPI(selectedDevice.device);
       const encoderValues = await Promise.all(
         Array(maxEncoder)
           .fill(0)
@@ -84,8 +86,8 @@ export const Pane: FC = () => {
                 .fill(0)
                 .map((_, j) =>
                   Promise.all([
-                    selectedDevice.api.getEncoderValue(j, i, false),
-                    selectedDevice.api.getEncoderValue(j, i, true),
+                    api.getEncoderValue(j, i, false),
+                    api.getEncoderValue(j, i, true),
                   ]).then(
                     (a) =>
                       a.map(
@@ -199,13 +201,15 @@ export const Pane: FC = () => {
       );
 
       await dispatch(saveRawKeymapToDevice(keymap, selectedDevice));
+
+      const api = new KeyboardAPI(selectedDevice.device);
       if (saveFile.encoders) {
         await Promise.all(
           saveFile.encoders.map((encoder, id) =>
             Promise.all(
               encoder.map((layer, layerId) =>
                 Promise.all([
-                  selectedDevice.api.setEncoderValue(
+                  api.setEncoderValue(
                     layerId,
                     id,
                     false,
@@ -214,7 +218,7 @@ export const Pane: FC = () => {
                       basicKeyToByte,
                     ),
                   ),
-                  selectedDevice.api.setEncoderValue(
+                  api.setEncoderValue(
                     layerId,
                     id,
                     true,

--- a/src/components/panes/configure-panes/save-load.tsx
+++ b/src/components/panes/configure-panes/save-load.tsx
@@ -20,7 +20,7 @@ import {
 import {useAppDispatch, useAppSelector} from 'src/store/hooks';
 import {
   getSelectedConnectedDevice,
-  getSelectedKeyboardApi,
+  getSelectedKeyboardAPI,
 } from 'src/store/devicesSlice';
 import {getExpressions, saveMacros} from 'src/store/macrosSlice';
 
@@ -51,7 +51,7 @@ export const Pane: FC = () => {
   const dispatch = useAppDispatch();
   const selectedDefinition = useAppSelector(getSelectedDefinition);
   const selectedDevice = useAppSelector(getSelectedConnectedDevice);
-  const api = useAppSelector(getSelectedKeyboardApi);
+  const api = useAppSelector(getSelectedKeyboardAPI);
   const rawLayers = useAppSelector(getSelectedRawLayers);
   const macros = useAppSelector((state) => state.macros);
   const expressions = useAppSelector(getExpressions);

--- a/src/components/panes/configure-panes/submenus/macros/macro-detail.tsx
+++ b/src/components/panes/configure-panes/submenus/macros/macro-detail.tsx
@@ -11,6 +11,7 @@ import {ProgressBarTooltip} from 'src/components/inputs/tooltip';
 import {getMacroBufferSize} from 'src/store/macrosSlice';
 import {getSelectedConnectedDevice} from 'src/store/devicesSlice';
 import {getMacroAPI} from 'src/utils/macro-api';
+import {KeyboardAPI} from 'src/utils/keyboard-api';
 
 const ProgressBarContainer = styled.div`
   position: relative;
@@ -98,7 +99,8 @@ const BufferSizeUsage = () => {
   if (!connectedDevice) {
     return null;
   }
-  const {protocol, api} = connectedDevice;
+  const {protocol, device} = connectedDevice;
+  const api = new KeyboardAPI(device);
   const macroApi = getMacroAPI(protocol, api);
   const bytesUsed = macroApi.rawKeycodeSequencesToMacroBytes(ast).length;
   return (

--- a/src/components/panes/configure-panes/submenus/macros/macro-detail.tsx
+++ b/src/components/panes/configure-panes/submenus/macros/macro-detail.tsx
@@ -11,7 +11,7 @@ import {ProgressBarTooltip} from 'src/components/inputs/tooltip';
 import {getMacroBufferSize} from 'src/store/macrosSlice';
 import {
   getSelectedConnectedDevice,
-  getSelectedKeyboardApi,
+  getSelectedKeyboardAPI,
 } from 'src/store/devicesSlice';
 import {getMacroAPI} from 'src/utils/macro-api';
 
@@ -98,7 +98,7 @@ const BufferSizeUsage = () => {
   const ast = useAppSelector((state) => state.macros.ast);
   const bufferSize = useAppSelector(getMacroBufferSize);
   const connectedDevice = useAppSelector(getSelectedConnectedDevice);
-  const api = useAppSelector(getSelectedKeyboardApi);
+  const api = useAppSelector(getSelectedKeyboardAPI);
   if (!connectedDevice || !api) {
     return null;
   }

--- a/src/components/panes/configure-panes/submenus/macros/macro-detail.tsx
+++ b/src/components/panes/configure-panes/submenus/macros/macro-detail.tsx
@@ -9,9 +9,11 @@ import {faCode, faGear} from '@fortawesome/free-solid-svg-icons';
 import {ScriptMode} from './script-mode';
 import {ProgressBarTooltip} from 'src/components/inputs/tooltip';
 import {getMacroBufferSize} from 'src/store/macrosSlice';
-import {getSelectedConnectedDevice} from 'src/store/devicesSlice';
+import {
+  getSelectedConnectedDevice,
+  getSelectedKeyboardApi,
+} from 'src/store/devicesSlice';
 import {getMacroAPI} from 'src/utils/macro-api';
-import {KeyboardAPI} from 'src/utils/keyboard-api';
 
 const ProgressBarContainer = styled.div`
   position: relative;
@@ -96,11 +98,11 @@ const BufferSizeUsage = () => {
   const ast = useAppSelector((state) => state.macros.ast);
   const bufferSize = useAppSelector(getMacroBufferSize);
   const connectedDevice = useAppSelector(getSelectedConnectedDevice);
-  if (!connectedDevice) {
+  const api = useAppSelector(getSelectedKeyboardApi);
+  if (!connectedDevice || !api) {
     return null;
   }
-  const {protocol, path} = connectedDevice;
-  const api = new KeyboardAPI(path);
+  const {protocol} = connectedDevice;
   const macroApi = getMacroAPI(protocol, api);
   const bytesUsed = macroApi.rawKeycodeSequencesToMacroBytes(ast).length;
   return (

--- a/src/components/panes/configure-panes/submenus/macros/macro-detail.tsx
+++ b/src/components/panes/configure-panes/submenus/macros/macro-detail.tsx
@@ -99,8 +99,8 @@ const BufferSizeUsage = () => {
   if (!connectedDevice) {
     return null;
   }
-  const {protocol, device} = connectedDevice;
-  const api = new KeyboardAPI(device);
+  const {protocol, path} = connectedDevice;
+  const api = new KeyboardAPI(path);
   const macroApi = getMacroAPI(protocol, api);
   const bytesUsed = macroApi.rawKeycodeSequencesToMacroBytes(ast).length;
   return (

--- a/src/components/panes/debug.tsx
+++ b/src/components/panes/debug.tsx
@@ -1,7 +1,7 @@
 import {useState, FC, useEffect, useCallback} from 'react';
 import {Pane} from './pane';
 import styled from 'styled-components';
-import {KeyboardValue} from '../../utils/keyboard-api';
+import {KeyboardAPI, KeyboardValue} from '../../utils/keyboard-api';
 import {anyKeycodeToString} from '../../utils/advanced-keys';
 import {MusicalKeySlider} from '../inputs/musical-key-slider';
 import {AccentSelect} from '../inputs/accent-select';
@@ -216,7 +216,7 @@ const TestControls = () => {
 
 export const Debug: FC = () => {
   const selectedDevice = useAppSelector(getSelectedConnectedDevice);
-  const api = selectedDevice ? selectedDevice.api : null;
+  const api = selectedDevice ? new KeyboardAPI(selectedDevice.device) : null;
   const connectedDevices = useAppSelector(getConnectedDevices);
 
   // Temporary patch that gets the page to load

--- a/src/components/panes/debug.tsx
+++ b/src/components/panes/debug.tsx
@@ -24,7 +24,7 @@ import {AccentRange} from '../inputs/accent-range';
 import {useAppSelector} from 'src/store/hooks';
 import {
   getConnectedDevices,
-  getSelectedKeyboardApi,
+  getSelectedKeyboardAPI,
 } from 'src/store/devicesSlice';
 import {
   getBaseDefinitions,
@@ -215,7 +215,7 @@ const TestControls = () => {
 };
 
 export const Debug: FC = () => {
-  const api = useAppSelector(getSelectedKeyboardApi);
+  const api = useAppSelector(getSelectedKeyboardAPI);
   const connectedDevices = useAppSelector(getConnectedDevices);
 
   // Temporary patch that gets the page to load

--- a/src/components/panes/debug.tsx
+++ b/src/components/panes/debug.tsx
@@ -1,7 +1,7 @@
 import {useState, FC, useEffect, useCallback} from 'react';
 import {Pane} from './pane';
 import styled from 'styled-components';
-import {KeyboardAPI, KeyboardValue} from '../../utils/keyboard-api';
+import {KeyboardValue} from '../../utils/keyboard-api';
 import {anyKeycodeToString} from '../../utils/advanced-keys';
 import {MusicalKeySlider} from '../inputs/musical-key-slider';
 import {AccentSelect} from '../inputs/accent-select';
@@ -24,7 +24,7 @@ import {AccentRange} from '../inputs/accent-range';
 import {useAppSelector} from 'src/store/hooks';
 import {
   getConnectedDevices,
-  getSelectedConnectedDevice,
+  getSelectedKeyboardApi,
 } from 'src/store/devicesSlice';
 import {
   getBaseDefinitions,
@@ -215,8 +215,7 @@ const TestControls = () => {
 };
 
 export const Debug: FC = () => {
-  const selectedDevice = useAppSelector(getSelectedConnectedDevice);
-  const api = selectedDevice ? new KeyboardAPI(selectedDevice.path) : null;
+  const api = useAppSelector(getSelectedKeyboardApi);
   const connectedDevices = useAppSelector(getConnectedDevices);
 
   // Temporary patch that gets the page to load

--- a/src/components/panes/debug.tsx
+++ b/src/components/panes/debug.tsx
@@ -216,7 +216,7 @@ const TestControls = () => {
 
 export const Debug: FC = () => {
   const selectedDevice = useAppSelector(getSelectedConnectedDevice);
-  const api = selectedDevice ? new KeyboardAPI(selectedDevice.device) : null;
+  const api = selectedDevice ? new KeyboardAPI(selectedDevice.path) : null;
   const connectedDevices = useAppSelector(getConnectedDevices);
 
   // Temporary patch that gets the page to load
@@ -392,7 +392,7 @@ export const Debug: FC = () => {
               ) as KeyboardDefinitionEntry;
               if (definitionEntry) {
                 return (
-                  <IndentedControlRow key={device.device.path}>
+                  <IndentedControlRow key={device.path}>
                     <SubLabel>
                       {
                         (

--- a/src/components/three-fiber/keyboard.tsx
+++ b/src/components/three-fiber/keyboard.tsx
@@ -16,7 +16,7 @@ import {
 } from 'src/store/keymapSlice';
 import {KeyboardCanvas} from './keyboard-canvas';
 import {useLocation} from 'wouter';
-import {getSelectedKeyboardApi} from 'src/store/devicesSlice';
+import {getSelectedKeyboardAPI} from 'src/store/devicesSlice';
 import {
   getIsTestMatrixEnabled,
   setTestMatrixEnabled,
@@ -321,7 +321,7 @@ export const Test = (props: {dimensions?: DOMRect}) => {
   const dispatch = useAppDispatch();
   const [path] = useLocation();
   const isShowingTest = path === '/test';
-  const api = useAppSelector(getSelectedKeyboardApi);
+  const api = useAppSelector(getSelectedKeyboardAPI);
   const selectedDefinition = useAppSelector(getSelectedDefinition);
   const keyDefinitions = useAppSelector(getSelectedKeyDefinitions);
   const isTestMatrixEnabled = useAppSelector(getIsTestMatrixEnabled);

--- a/src/components/three-fiber/keyboard.tsx
+++ b/src/components/three-fiber/keyboard.tsx
@@ -36,6 +36,7 @@ import {
   getSelectedCustomMenuData,
   getShowKeyPainter,
 } from 'src/store/menusSlice';
+import {KeyboardAPI} from 'src/utils/keyboard-api';
 
 enum DisplayMode {
   Test = 1,
@@ -329,7 +330,10 @@ export const Test = (props: {dimensions?: DOMRect}) => {
     (state) => getSelectedKeymap(state) || [],
   );
 
-  const api = selectedDevice && selectedDevice.api;
+  const api =
+    selectedDevice &&
+    selectedDevice.device &&
+    new KeyboardAPI(selectedDevice.device);
   const [globalPressedKeys, setGlobalPressedKeys] = useGlobalKeys(
     !isTestMatrixEnabled && isShowingTest,
   );

--- a/src/components/three-fiber/keyboard.tsx
+++ b/src/components/three-fiber/keyboard.tsx
@@ -16,7 +16,7 @@ import {
 } from 'src/store/keymapSlice';
 import {KeyboardCanvas} from './keyboard-canvas';
 import {useLocation} from 'wouter';
-import {getSelectedConnectedDevice} from 'src/store/devicesSlice';
+import {getSelectedKeyboardApi} from 'src/store/devicesSlice';
 import {
   getIsTestMatrixEnabled,
   setTestMatrixEnabled,
@@ -36,7 +36,6 @@ import {
   getSelectedCustomMenuData,
   getShowKeyPainter,
 } from 'src/store/menusSlice';
-import {KeyboardAPI} from 'src/utils/keyboard-api';
 
 enum DisplayMode {
   Test = 1,
@@ -322,7 +321,7 @@ export const Test = (props: {dimensions?: DOMRect}) => {
   const dispatch = useAppDispatch();
   const [path] = useLocation();
   const isShowingTest = path === '/test';
-  const selectedDevice = useAppSelector(getSelectedConnectedDevice);
+  const api = useAppSelector(getSelectedKeyboardApi);
   const selectedDefinition = useAppSelector(getSelectedDefinition);
   const keyDefinitions = useAppSelector(getSelectedKeyDefinitions);
   const isTestMatrixEnabled = useAppSelector(getIsTestMatrixEnabled);
@@ -330,10 +329,6 @@ export const Test = (props: {dimensions?: DOMRect}) => {
     (state) => getSelectedKeymap(state) || [],
   );
 
-  const api =
-    selectedDevice &&
-    selectedDevice.path &&
-    new KeyboardAPI(selectedDevice.path);
   const [globalPressedKeys, setGlobalPressedKeys] = useGlobalKeys(
     !isTestMatrixEnabled && isShowingTest,
   );

--- a/src/components/three-fiber/keyboard.tsx
+++ b/src/components/three-fiber/keyboard.tsx
@@ -332,8 +332,8 @@ export const Test = (props: {dimensions?: DOMRect}) => {
 
   const api =
     selectedDevice &&
-    selectedDevice.device &&
-    new KeyboardAPI(selectedDevice.device);
+    selectedDevice.path &&
+    new KeyboardAPI(selectedDevice.path);
   const [globalPressedKeys, setGlobalPressedKeys] = useGlobalKeys(
     !isTestMatrixEnabled && isShowingTest,
   );

--- a/src/components/two-string/keyboard.tsx
+++ b/src/components/two-string/keyboard.tsx
@@ -16,7 +16,7 @@ import {
 } from 'src/store/keymapSlice';
 import {KeyboardCanvas} from './keyboard-canvas';
 import {useLocation} from 'wouter';
-import {getSelectedKeyboardApi} from 'src/store/devicesSlice';
+import {getSelectedKeyboardAPI} from 'src/store/devicesSlice';
 import {
   getIsTestMatrixEnabled,
   setTestMatrixEnabled,
@@ -321,7 +321,7 @@ export const Test = (props: {dimensions?: DOMRect}) => {
   const dispatch = useAppDispatch();
   const [path] = useLocation();
   const isShowingTest = path === '/test';
-  const api = useAppSelector(getSelectedKeyboardApi);
+  const api = useAppSelector(getSelectedKeyboardAPI);
   const selectedDefinition = useAppSelector(getSelectedDefinition);
   const keyDefinitions = useAppSelector(getSelectedKeyDefinitions);
   const isTestMatrixEnabled = useAppSelector(getIsTestMatrixEnabled);

--- a/src/components/two-string/keyboard.tsx
+++ b/src/components/two-string/keyboard.tsx
@@ -36,6 +36,7 @@ import {
   getSelectedCustomMenuData,
   getShowKeyPainter,
 } from 'src/store/menusSlice';
+import {KeyboardAPI} from 'src/utils/keyboard-api';
 
 enum DisplayMode {
   Test = 1,
@@ -329,7 +330,10 @@ export const Test = (props: {dimensions?: DOMRect}) => {
     (state) => getSelectedKeymap(state) || [],
   );
 
-  const api = selectedDevice && selectedDevice.api;
+  const api =
+    selectedDevice &&
+    selectedDevice.device &&
+    new KeyboardAPI(selectedDevice.device);
   const [globalPressedKeys, setGlobalPressedKeys] = useGlobalKeys(
     !isTestMatrixEnabled && isShowingTest,
   );

--- a/src/components/two-string/keyboard.tsx
+++ b/src/components/two-string/keyboard.tsx
@@ -16,7 +16,7 @@ import {
 } from 'src/store/keymapSlice';
 import {KeyboardCanvas} from './keyboard-canvas';
 import {useLocation} from 'wouter';
-import {getSelectedConnectedDevice} from 'src/store/devicesSlice';
+import {getSelectedKeyboardApi} from 'src/store/devicesSlice';
 import {
   getIsTestMatrixEnabled,
   setTestMatrixEnabled,
@@ -36,7 +36,6 @@ import {
   getSelectedCustomMenuData,
   getShowKeyPainter,
 } from 'src/store/menusSlice';
-import {KeyboardAPI} from 'src/utils/keyboard-api';
 
 enum DisplayMode {
   Test = 1,
@@ -322,7 +321,7 @@ export const Test = (props: {dimensions?: DOMRect}) => {
   const dispatch = useAppDispatch();
   const [path] = useLocation();
   const isShowingTest = path === '/test';
-  const selectedDevice = useAppSelector(getSelectedConnectedDevice);
+  const api = useAppSelector(getSelectedKeyboardApi);
   const selectedDefinition = useAppSelector(getSelectedDefinition);
   const keyDefinitions = useAppSelector(getSelectedKeyDefinitions);
   const isTestMatrixEnabled = useAppSelector(getIsTestMatrixEnabled);
@@ -330,10 +329,6 @@ export const Test = (props: {dimensions?: DOMRect}) => {
     (state) => getSelectedKeymap(state) || [],
   );
 
-  const api =
-    selectedDevice &&
-    selectedDevice.path &&
-    new KeyboardAPI(selectedDevice.path);
   const [globalPressedKeys, setGlobalPressedKeys] = useGlobalKeys(
     !isTestMatrixEnabled && isShowingTest,
   );

--- a/src/components/two-string/keyboard.tsx
+++ b/src/components/two-string/keyboard.tsx
@@ -332,8 +332,8 @@ export const Test = (props: {dimensions?: DOMRect}) => {
 
   const api =
     selectedDevice &&
-    selectedDevice.device &&
-    new KeyboardAPI(selectedDevice.device);
+    selectedDevice.path &&
+    new KeyboardAPI(selectedDevice.path);
   const [globalPressedKeys, setGlobalPressedKeys] = useGlobalKeys(
     !isTestMatrixEnabled && isShowingTest,
   );

--- a/src/shims/node-hid.ts
+++ b/src/shims/node-hid.ts
@@ -35,6 +35,7 @@ const tagDevice = (device: HIDDevice) => {
   };
   return (ExtendedHID._cache[path] = HIDDevice);
 };
+
 const ExtendedHID = {
   _cache: {} as {[key: string]: any},
   requestDevice: async () => {

--- a/src/shims/node-hid.ts
+++ b/src/shims/node-hid.ts
@@ -18,7 +18,7 @@ const getVIAPathIdentifier = () =>
   (self.crypto && self.crypto.randomUUID && self.crypto.randomUUID()) ||
   `via-path:${Math.random()}`;
 
-const tagDevice = (device: HIDDevice) => {
+const tagDevice = (device: HIDDevice): WebVIADevice => {
   // This is super important in order to have a stable way to identify the same device
   // that was already scanned. It's a bit hacky but https://github.com/WICG/webhid/issues/7
   // ¯\_(ツ)_/¯
@@ -37,7 +37,7 @@ const tagDevice = (device: HIDDevice) => {
 };
 
 const ExtendedHID = {
-  _cache: {} as {[key: string]: any},
+  _cache: {} as {[key: string]: WebVIADevice},
   requestDevice: async () => {
     const requestedDevice = await navigator.hid.requestDevice({
       filters: [

--- a/src/store/definitionsSlice.ts
+++ b/src/store/definitionsSlice.ts
@@ -20,7 +20,7 @@ import {
   getSelectedDevicePath,
   getSelectedConnectedDevice,
   ensureSupportedIds,
-  getSelectedKeyboardApi,
+  getSelectedKeyboardAPI,
 } from './devicesSlice';
 import {getMissingDefinition} from 'src/utils/device-store';
 import {getBasicKeyDict} from 'src/utils/key-to-byte/dictionary-store';
@@ -196,7 +196,7 @@ export const updateLayoutOption =
   async (dispatch, getState) => {
     const state = getState();
     const definition = getSelectedDefinition(state);
-    const api = getSelectedKeyboardApi(state);
+    const api = getSelectedKeyboardAPI(state);
     const path = getSelectedDevicePath(state);
 
     if (!definition || !api || !path || !definition.layouts.labels) {
@@ -290,7 +290,7 @@ export const loadLayoutOptions = (): AppThunk => async (dispatch, getState) => {
   const state = getState();
   const selectedDefinition = getSelectedDefinition(state);
   const connectedDevice = getSelectedConnectedDevice(state);
-  const api = getSelectedKeyboardApi(state);
+  const api = getSelectedKeyboardAPI(state);
   if (
     !connectedDevice ||
     !selectedDefinition ||

--- a/src/store/definitionsSlice.ts
+++ b/src/store/definitionsSlice.ts
@@ -216,7 +216,7 @@ export const updateLayoutOption =
     );
 
     try {
-      const api = new KeyboardAPI(selectedDevice.device);
+      const api = new KeyboardAPI(selectedDevice.path);
       await api.setKeyboardValue(KeyboardValue.LAYOUT_OPTIONS, ...bytes);
     } catch {
       console.warn('Setting layout option command not working');
@@ -298,9 +298,9 @@ export const loadLayoutOptions = (): AppThunk => async (dispatch, getState) => {
     return;
   }
 
-  const {device} = connectedDevice;
+  const {path} = connectedDevice;
   try {
-    const api = new KeyboardAPI(device);
+    const api = new KeyboardAPI(path);
     const res = await api.getKeyboardValue(KeyboardValue.LAYOUT_OPTIONS, 4);
     const options = unpackBits(
       bytesIntoNum(res),
@@ -310,7 +310,7 @@ export const loadLayoutOptions = (): AppThunk => async (dispatch, getState) => {
     );
     dispatch(
       updateLayoutOptions({
-        [device.path]: options,
+        [path]: options,
       }),
     );
   } catch {
@@ -334,8 +334,8 @@ export const reloadDefinitions =
           );
         })
         // Go and get it if we don't
-        .map(({device, requiredDefinitionVersion}) =>
-          getMissingDefinition(device, requiredDefinitionVersion),
+        .map((device) =>
+          getMissingDefinition(device, device.requiredDefinitionVersion),
         ),
     );
     if (!missingDefinitions.length) {

--- a/src/store/devicesSlice.ts
+++ b/src/store/devicesSlice.ts
@@ -1,5 +1,6 @@
 import {createSelector, createSlice, PayloadAction} from '@reduxjs/toolkit';
 import type {DefinitionVersion} from '@the-via/reader';
+import {KeyboardAPI} from 'src/utils/keyboard-api';
 import type {
   ConnectedDevice,
   ConnectedDevices,
@@ -78,4 +79,8 @@ export const getSelectedConnectedDevice = createSelector(
   getConnectedDevices,
   getSelectedDevicePath,
   (devices, path) => path && devices[path],
+);
+export const getSelectedKeyboardApi = createSelector(
+  getSelectedDevicePath,
+  (path) => path && new KeyboardAPI(path),
 );

--- a/src/store/devicesSlice.ts
+++ b/src/store/devicesSlice.ts
@@ -80,7 +80,7 @@ export const getSelectedConnectedDevice = createSelector(
   getSelectedDevicePath,
   (devices, path) => path && devices[path],
 );
-export const getSelectedKeyboardApi = createSelector(
+export const getSelectedKeyboardAPI = createSelector(
   getSelectedDevicePath,
   (path) => path && new KeyboardAPI(path),
 );

--- a/src/store/devicesSlice.ts
+++ b/src/store/devicesSlice.ts
@@ -10,13 +10,13 @@ import type {RootState} from './index';
 
 export type DevicesState = {
   selectedDevicePath: string | null;
-  connectedDevices: ConnectedDevices;
+  connectedDevicePaths: ConnectedDevices;
   supportedIds: VendorProductIdMap;
 };
 
 const initialState: DevicesState = {
   selectedDevicePath: null,
-  connectedDevices: {},
+  connectedDevicePaths: {},
   supportedIds: {},
 };
 
@@ -29,18 +29,18 @@ export const deviceSlice = createSlice({
       if (!action.payload) {
         state.selectedDevicePath = null;
       } else {
-        state.selectedDevicePath = action.payload.device.path;
+        state.selectedDevicePath = action.payload.path;
       }
     },
     updateConnectedDevices: (
       state,
       action: PayloadAction<ConnectedDevices>,
     ) => {
-      state.connectedDevices = action.payload;
+      state.connectedDevicePaths = action.payload;
     },
     clearAllDevices: (state) => {
       state.selectedDevicePath = null;
-      state.connectedDevices = {};
+      state.connectedDevicePaths = {};
     },
     updateSupportedIds: (state, action: PayloadAction<VendorProductIdMap>) => {
       state.supportedIds = action.payload;
@@ -70,7 +70,7 @@ export const {
 export default deviceSlice.reducer;
 
 export const getConnectedDevices = (state: RootState) =>
-  state.devices.connectedDevices;
+  state.devices.connectedDevicePaths;
 export const getSelectedDevicePath = (state: RootState) =>
   state.devices.selectedDevicePath;
 export const getSupportedIds = (state: RootState) => state.devices.supportedIds;

--- a/src/store/devicesThunks.ts
+++ b/src/store/devicesThunks.ts
@@ -14,7 +14,6 @@ import {
   loadLayoutOptions,
   updateDefinitions,
   getDefinitions,
-  getBasicKeyToByte,
   loadStoredCustomDefinitions,
 } from './definitionsSlice';
 import {loadKeymapFromDevice} from './keymapSlice';

--- a/src/store/devicesThunks.ts
+++ b/src/store/devicesThunks.ts
@@ -47,16 +47,16 @@ export const selectConnectedDeviceByPath =
   };
 
 const validateDefinitionAvailable = async (
-  {device, requiredDefinitionVersion, vendorProductId}: ConnectedDevice,
+  device: ConnectedDevice,
   definitions: KeyboardDictionary,
 ) => {
   const definition =
     definitions &&
-    definitions[vendorProductId] &&
-    definitions[vendorProductId][requiredDefinitionVersion];
+    definitions[device.vendorProductId] &&
+    definitions[device.vendorProductId][device.requiredDefinitionVersion];
   if (!definition) {
     console.log('missing definition: fetching new one');
-    await getMissingDefinition(device, requiredDefinitionVersion);
+    await getMissingDefinition(device, device.requiredDefinitionVersion);
   }
 };
 
@@ -112,15 +112,18 @@ export const reloadConnectedDevices =
 
     const protocolVersions = await Promise.all(
       recognisedDevices.map((device) =>
-        new KeyboardAPI(device).getProtocolVersion(),
+        new KeyboardAPI(device.path).getProtocolVersion(),
       ),
     );
 
     const connectedDevices = recognisedDevices.reduce<ConnectedDevices>(
       (devices, device, idx) => {
+        const {path, productId, vendorId} = device;
         const protocol = protocolVersions[idx];
         devices[device.path] = {
-          device,
+          path,
+          productId,
+          vendorId,
           protocol,
           requiredDefinitionVersion: protocol >= 11 ? 'v3' : 'v2',
           vendorProductId: getVendorProductId(

--- a/src/store/devicesThunks.ts
+++ b/src/store/devicesThunks.ts
@@ -70,9 +70,8 @@ export const selectConnectedDevice =
         connectedDevice,
         getDefinitions(getState()),
       );
-      const {basicKeyToByte} = getBasicKeyToByte(getState());
       dispatch(selectDevice(connectedDevice));
-      await dispatch(loadMacros(connectedDevice, basicKeyToByte));
+      await dispatch(loadMacros(connectedDevice));
       await dispatch(loadLayoutOptions());
 
       const {protocol} = connectedDevice;
@@ -121,7 +120,6 @@ export const reloadConnectedDevices =
       (devices, device, idx) => {
         const protocol = protocolVersions[idx];
         devices[device.path] = {
-          api: new KeyboardAPI(device),
           device,
           protocol,
           requiredDefinitionVersion: protocol >= 11 ? 'v3' : 'v2',

--- a/src/store/keymapSlice.ts
+++ b/src/store/keymapSlice.ts
@@ -14,7 +14,7 @@ import {
 import {
   getSelectedConnectedDevice,
   getSelectedDevicePath,
-  getSelectedKeyboardApi,
+  getSelectedKeyboardAPI,
   selectDevice,
 } from './devicesSlice';
 import {KeyboardAPI} from 'src/utils/keyboard-api';
@@ -139,7 +139,7 @@ export const loadKeymapFromDevice =
     }
 
     const {path, vendorProductId, requiredDefinitionVersion} = connectedDevice;
-    const api = getSelectedKeyboardApi(state) as KeyboardAPI;
+    const api = getSelectedKeyboardAPI(state) as KeyboardAPI;
 
     const numberOfLayers = await api.getLayerCount();
     dispatch(setNumberOfLayers(numberOfLayers));
@@ -160,7 +160,7 @@ export const saveRawKeymapToDevice =
   async (dispatch, getState) => {
     const state = getState();
     const {path} = connectedDevice;
-    const api = getSelectedKeyboardApi(state);
+    const api = getSelectedKeyboardAPI(state);
     const definition = getSelectedDefinition(state);
     if (!path || !definition || !api) {
       return;
@@ -182,7 +182,7 @@ export const updateKey =
     const state = getState();
     const keys = getSelectedKeyDefinitions(state);
     const connectedDevice = getSelectedConnectedDevice(state);
-    const api = getSelectedKeyboardApi(state);
+    const api = getSelectedKeyboardAPI(state);
     const selectedDefinition = getSelectedDefinition(state);
     if (!connectedDevice || !keys || !selectedDefinition || !api) {
       return;

--- a/src/store/keymapSlice.ts
+++ b/src/store/keymapSlice.ts
@@ -137,10 +137,9 @@ export const loadKeymapFromDevice =
       return;
     }
 
-    const {device, vendorProductId, requiredDefinitionVersion} =
-      connectedDevice;
+    const {path, vendorProductId, requiredDefinitionVersion} = connectedDevice;
 
-    const api = new KeyboardAPI(device);
+    const api = new KeyboardAPI(path);
 
     const numberOfLayers = await api.getLayerCount();
     dispatch(setNumberOfLayers(numberOfLayers));
@@ -150,7 +149,7 @@ export const loadKeymapFromDevice =
 
     for (var layerIndex = 0; layerIndex < numberOfLayers; layerIndex++) {
       const keymap = await api.readRawMatrix(matrix, layerIndex);
-      dispatch(loadLayerSuccess({layerIndex, keymap, devicePath: device.path}));
+      dispatch(loadLayerSuccess({layerIndex, keymap, devicePath: path}));
     }
   };
 
@@ -160,13 +159,13 @@ export const saveRawKeymapToDevice =
   (keymap: number[][], connectedDevice: ConnectedDevice): AppThunk =>
   async (dispatch, getState) => {
     const state = getState();
-    const {device} = connectedDevice;
+    const {path} = connectedDevice;
     const definition = getSelectedDefinition(state);
-    if (!device || !definition) {
+    if (!path || !definition) {
       return;
     }
 
-    const api = new KeyboardAPI(device);
+    const api = new KeyboardAPI(path);
     const {matrix} = definition;
 
     await api.writeRawMatrix(matrix, keymap);
@@ -174,9 +173,7 @@ export const saveRawKeymapToDevice =
       keymap: layer,
       isLoaded: true,
     }));
-    dispatch(
-      saveKeymapSuccess({layers, devicePath: connectedDevice.device.path}),
-    );
+    dispatch(saveKeymapSuccess({layers, devicePath: path}));
   };
 
 export const updateKey =
@@ -191,15 +188,15 @@ export const updateKey =
     }
 
     const selectedLayerIndex = getSelectedLayerIndex(state);
-    const {device} = connectedDevice;
-    const api = new KeyboardAPI(device);
+    const {path} = connectedDevice;
+    const api = new KeyboardAPI(path);
     const {row, col} = keys[keyIndex];
     await api.setKey(selectedLayerIndex, row, col, value);
 
     const {matrix} = selectedDefinition;
     const keymapIndex = row * matrix.cols + col;
 
-    dispatch(setKey({keymapIndex, value, devicePath: device.path}));
+    dispatch(setKey({keymapIndex, value, devicePath: path}));
   };
 
 export const getConfigureKeyboardIsSelectable = (state: RootState) =>

--- a/src/store/keymapSlice.ts
+++ b/src/store/keymapSlice.ts
@@ -14,6 +14,7 @@ import {
 import {
   getSelectedConnectedDevice,
   getSelectedDevicePath,
+  getSelectedKeyboardApi,
   selectDevice,
 } from './devicesSlice';
 import {KeyboardAPI} from 'src/utils/keyboard-api';
@@ -138,8 +139,7 @@ export const loadKeymapFromDevice =
     }
 
     const {path, vendorProductId, requiredDefinitionVersion} = connectedDevice;
-
-    const api = new KeyboardAPI(path);
+    const api = getSelectedKeyboardApi(state) as KeyboardAPI;
 
     const numberOfLayers = await api.getLayerCount();
     dispatch(setNumberOfLayers(numberOfLayers));
@@ -160,12 +160,12 @@ export const saveRawKeymapToDevice =
   async (dispatch, getState) => {
     const state = getState();
     const {path} = connectedDevice;
+    const api = getSelectedKeyboardApi(state);
     const definition = getSelectedDefinition(state);
-    if (!path || !definition) {
+    if (!path || !definition || !api) {
       return;
     }
 
-    const api = new KeyboardAPI(path);
     const {matrix} = definition;
 
     await api.writeRawMatrix(matrix, keymap);
@@ -182,14 +182,14 @@ export const updateKey =
     const state = getState();
     const keys = getSelectedKeyDefinitions(state);
     const connectedDevice = getSelectedConnectedDevice(state);
+    const api = getSelectedKeyboardApi(state);
     const selectedDefinition = getSelectedDefinition(state);
-    if (!connectedDevice || !keys || !selectedDefinition) {
+    if (!connectedDevice || !keys || !selectedDefinition || !api) {
       return;
     }
 
     const selectedLayerIndex = getSelectedLayerIndex(state);
     const {path} = connectedDevice;
-    const api = new KeyboardAPI(path);
     const {row, col} = keys[keyIndex];
     await api.setKey(selectedLayerIndex, row, col, value);
 

--- a/src/store/keymapSlice.ts
+++ b/src/store/keymapSlice.ts
@@ -16,6 +16,7 @@ import {
   getSelectedDevicePath,
   selectDevice,
 } from './devicesSlice';
+import {KeyboardAPI} from 'src/utils/keyboard-api';
 
 export type KeymapState = {
   rawDeviceMap: DeviceLayerMap;
@@ -136,8 +137,10 @@ export const loadKeymapFromDevice =
       return;
     }
 
-    const {api, device, vendorProductId, requiredDefinitionVersion} =
+    const {device, vendorProductId, requiredDefinitionVersion} =
       connectedDevice;
+
+    const api = new KeyboardAPI(device);
 
     const numberOfLayers = await api.getLayerCount();
     dispatch(setNumberOfLayers(numberOfLayers));
@@ -157,12 +160,13 @@ export const saveRawKeymapToDevice =
   (keymap: number[][], connectedDevice: ConnectedDevice): AppThunk =>
   async (dispatch, getState) => {
     const state = getState();
-    const {api} = connectedDevice;
+    const {device} = connectedDevice;
     const definition = getSelectedDefinition(state);
-    if (!api || !definition) {
+    if (!device || !definition) {
       return;
     }
 
+    const api = new KeyboardAPI(device);
     const {matrix} = definition;
 
     await api.writeRawMatrix(matrix, keymap);
@@ -187,7 +191,8 @@ export const updateKey =
     }
 
     const selectedLayerIndex = getSelectedLayerIndex(state);
-    const {api, device} = connectedDevice;
+    const {device} = connectedDevice;
+    const api = new KeyboardAPI(device);
     const {row, col} = keys[keyIndex];
     await api.setKey(selectedLayerIndex, row, col, value);
 

--- a/src/store/lightingSlice.ts
+++ b/src/store/lightingSlice.ts
@@ -11,6 +11,7 @@ import {
   getSelectedConnectedDevice,
   getSelectedDevicePath,
 } from './devicesSlice';
+import {KeyboardAPI} from 'src/utils/keyboard-api';
 
 type LightingMap = {[devicePath: string]: LightingData};
 
@@ -80,13 +81,15 @@ export const updateBacklightValue =
       ...selectedLightingData,
       [command]: [...rest],
     };
-    const {api, device} = connectedDevice;
+    const {device} = connectedDevice;
     dispatch(
       updateSelectedLightingData({
         lightingData,
         devicePath: device.path,
       }),
     );
+
+    const api = new KeyboardAPI(device);
     await api.setBacklightValue(command, ...rest);
     await api.saveLighting();
   };
@@ -108,10 +111,12 @@ export const updateCustomColor =
       ...oldLightingData,
       customColors,
     };
-    const {api, device} = connectedDevice;
+    const {device} = connectedDevice;
     dispatch(
       updateSelectedLightingData({lightingData, devicePath: device.path}),
     );
+
+    const api = new KeyboardAPI(device);
     api.setCustomColor(idx, hue, sat);
     await api.saveLighting();
   };
@@ -125,7 +130,7 @@ export const updateLightingData =
       return;
     }
 
-    const {api, device} = connectedDevice;
+    const {device} = connectedDevice;
     if (!isVIADefinitionV2(selectedDefinition)) {
       throw new Error('This method is only compatible with v2 definitions');
     }
@@ -135,6 +140,7 @@ export const updateLightingData =
 
     if (supportedLightingValues.length !== 0) {
       let props = {};
+      const api = new KeyboardAPI(device);
 
       // Special case for m6_b
       if (

--- a/src/store/lightingSlice.ts
+++ b/src/store/lightingSlice.ts
@@ -10,6 +10,7 @@ import {getSelectedDefinition} from './definitionsSlice';
 import {
   getSelectedConnectedDevice,
   getSelectedDevicePath,
+  getSelectedKeyboardApi,
 } from './devicesSlice';
 import {KeyboardAPI} from 'src/utils/keyboard-api';
 
@@ -89,7 +90,7 @@ export const updateBacklightValue =
       }),
     );
 
-    const api = new KeyboardAPI(path);
+    const api = getSelectedKeyboardApi(state) as KeyboardAPI;
     await api.setBacklightValue(command, ...rest);
     await api.saveLighting();
   };
@@ -99,8 +100,9 @@ export const updateCustomColor =
   async (dispatch, getState) => {
     const state = getState();
     const connectedDevice = getSelectedConnectedDevice(state);
+    const api = getSelectedKeyboardApi(state);
     const oldLightingData = getSelectedLightingData(state);
-    if (!connectedDevice || !oldLightingData) {
+    if (!connectedDevice || !oldLightingData || !api) {
       // TODO: shoud we be throwing instead of returning whenever we do these device checks in thunks?
       return;
     }
@@ -114,7 +116,6 @@ export const updateCustomColor =
     const {path} = connectedDevice;
     dispatch(updateSelectedLightingData({lightingData, devicePath: path}));
 
-    const api = new KeyboardAPI(path);
     api.setCustomColor(idx, hue, sat);
     await api.saveLighting();
   };
@@ -124,7 +125,8 @@ export const updateLightingData =
   async (dispatch, getState) => {
     const state = getState();
     const selectedDefinition = getSelectedDefinition(state);
-    if (!selectedDefinition) {
+    const api = getSelectedKeyboardApi(state);
+    if (!selectedDefinition || !api) {
       return;
     }
 
@@ -138,7 +140,6 @@ export const updateLightingData =
 
     if (supportedLightingValues.length !== 0) {
       let props = {};
-      const api = new KeyboardAPI(path);
 
       // Special case for m6_b
       if (

--- a/src/store/lightingSlice.ts
+++ b/src/store/lightingSlice.ts
@@ -81,15 +81,15 @@ export const updateBacklightValue =
       ...selectedLightingData,
       [command]: [...rest],
     };
-    const {device} = connectedDevice;
+    const {path} = connectedDevice;
     dispatch(
       updateSelectedLightingData({
         lightingData,
-        devicePath: device.path,
+        devicePath: path,
       }),
     );
 
-    const api = new KeyboardAPI(device);
+    const api = new KeyboardAPI(path);
     await api.setBacklightValue(command, ...rest);
     await api.saveLighting();
   };
@@ -111,12 +111,10 @@ export const updateCustomColor =
       ...oldLightingData,
       customColors,
     };
-    const {device} = connectedDevice;
-    dispatch(
-      updateSelectedLightingData({lightingData, devicePath: device.path}),
-    );
+    const {path} = connectedDevice;
+    dispatch(updateSelectedLightingData({lightingData, devicePath: path}));
 
-    const api = new KeyboardAPI(device);
+    const api = new KeyboardAPI(path);
     api.setCustomColor(idx, hue, sat);
     await api.saveLighting();
   };
@@ -130,7 +128,7 @@ export const updateLightingData =
       return;
     }
 
-    const {device} = connectedDevice;
+    const {path} = connectedDevice;
     if (!isVIADefinitionV2(selectedDefinition)) {
       throw new Error('This method is only compatible with v2 definitions');
     }
@@ -140,7 +138,7 @@ export const updateLightingData =
 
     if (supportedLightingValues.length !== 0) {
       let props = {};
-      const api = new KeyboardAPI(device);
+      const api = new KeyboardAPI(path);
 
       // Special case for m6_b
       if (
@@ -172,7 +170,7 @@ export const updateLightingData =
 
       dispatch(
         updateLighting({
-          [device.path]: {
+          [path]: {
             ...props,
           },
         }),

--- a/src/store/lightingSlice.ts
+++ b/src/store/lightingSlice.ts
@@ -10,7 +10,7 @@ import {getSelectedDefinition} from './definitionsSlice';
 import {
   getSelectedConnectedDevice,
   getSelectedDevicePath,
-  getSelectedKeyboardApi,
+  getSelectedKeyboardAPI,
 } from './devicesSlice';
 import {KeyboardAPI} from 'src/utils/keyboard-api';
 
@@ -90,7 +90,7 @@ export const updateBacklightValue =
       }),
     );
 
-    const api = getSelectedKeyboardApi(state) as KeyboardAPI;
+    const api = getSelectedKeyboardAPI(state) as KeyboardAPI;
     await api.setBacklightValue(command, ...rest);
     await api.saveLighting();
   };
@@ -100,7 +100,7 @@ export const updateCustomColor =
   async (dispatch, getState) => {
     const state = getState();
     const connectedDevice = getSelectedConnectedDevice(state);
-    const api = getSelectedKeyboardApi(state);
+    const api = getSelectedKeyboardAPI(state);
     const oldLightingData = getSelectedLightingData(state);
     if (!connectedDevice || !oldLightingData || !api) {
       // TODO: shoud we be throwing instead of returning whenever we do these device checks in thunks?
@@ -125,7 +125,7 @@ export const updateLightingData =
   async (dispatch, getState) => {
     const state = getState();
     const selectedDefinition = getSelectedDefinition(state);
-    const api = getSelectedKeyboardApi(state);
+    const api = getSelectedKeyboardAPI(state);
     if (!selectedDefinition || !api) {
       return;
     }

--- a/src/store/macrosSlice.ts
+++ b/src/store/macrosSlice.ts
@@ -57,12 +57,12 @@ export default macrosSlice.reducer;
 export const loadMacros =
   (connectedDevice: ConnectedDevice): AppThunk =>
   async (dispatch) => {
-    const {device, protocol} = connectedDevice;
+    const {path, protocol} = connectedDevice;
     if (protocol < 8) {
       dispatch(setMacrosNotSupported());
     } else {
       try {
-        const api = new KeyboardAPI(device);
+        const api = new KeyboardAPI(path);
         const macroApi = getMacroAPI(protocol, api);
         if (macroApi) {
           const sequences = await macroApi.readRawKeycodeSequences();
@@ -78,8 +78,8 @@ export const loadMacros =
 export const saveMacros =
   (connectedDevice: ConnectedDevice, macros: string[]): AppThunk =>
   async (dispatch) => {
-    const {device, protocol} = connectedDevice;
-    const api = new KeyboardAPI(device);
+    const {path, protocol} = connectedDevice;
+    const api = new KeyboardAPI(path);
     const macroApi = getMacroAPI(protocol, api);
     if (macroApi) {
       const sequences = macros.map((expression) => {

--- a/src/store/macrosSlice.ts
+++ b/src/store/macrosSlice.ts
@@ -9,7 +9,7 @@ import {
 } from 'src/utils/macro-api/macro-api.common';
 import {RawKeycodeSequence} from 'src/utils/macro-api/types';
 import type {ConnectedDevice} from '../types/types';
-import {getSelectedKeyboardApi} from './devicesSlice';
+import {getSelectedKeyboardAPI} from './devicesSlice';
 import type {AppThunk, RootState} from './index';
 
 export type MacrosState = {
@@ -64,7 +64,7 @@ export const loadMacros =
     } else {
       try {
         const state = getState();
-        const api = getSelectedKeyboardApi(state) as KeyboardAPI;
+        const api = getSelectedKeyboardAPI(state) as KeyboardAPI;
         const macroApi = getMacroAPI(protocol, api);
         if (macroApi) {
           const sequences = await macroApi.readRawKeycodeSequences();
@@ -81,7 +81,7 @@ export const saveMacros =
   (connectedDevice: ConnectedDevice, macros: string[]): AppThunk =>
   async (dispatch, getState) => {
     const state = getState();
-    const api = getSelectedKeyboardApi(state) as KeyboardAPI;
+    const api = getSelectedKeyboardAPI(state) as KeyboardAPI;
     const {protocol} = connectedDevice;
     const macroApi = getMacroAPI(protocol, api);
     if (macroApi) {

--- a/src/store/macrosSlice.ts
+++ b/src/store/macrosSlice.ts
@@ -1,4 +1,5 @@
 import {createSelector, createSlice, PayloadAction} from '@reduxjs/toolkit';
+import {KeyboardAPI} from 'src/utils/keyboard-api';
 import {getMacroAPI} from 'src/utils/macro-api';
 import {
   expressionToSequence,
@@ -54,16 +55,14 @@ export const {loadMacrosSuccess, saveMacrosSuccess, setMacrosNotSupported} =
 export default macrosSlice.reducer;
 
 export const loadMacros =
-  (
-    connectedDevice: ConnectedDevice,
-    basicKeyToByte: Record<string, number>,
-  ): AppThunk =>
+  (connectedDevice: ConnectedDevice): AppThunk =>
   async (dispatch) => {
-    const {api, protocol} = connectedDevice;
+    const {device, protocol} = connectedDevice;
     if (protocol < 8) {
       dispatch(setMacrosNotSupported());
     } else {
       try {
+        const api = new KeyboardAPI(device);
         const macroApi = getMacroAPI(protocol, api);
         if (macroApi) {
           const sequences = await macroApi.readRawKeycodeSequences();
@@ -79,7 +78,8 @@ export const loadMacros =
 export const saveMacros =
   (connectedDevice: ConnectedDevice, macros: string[]): AppThunk =>
   async (dispatch) => {
-    const {api, protocol} = connectedDevice;
+    const {device, protocol} = connectedDevice;
+    const api = new KeyboardAPI(device);
     const macroApi = getMacroAPI(protocol, api);
     if (macroApi) {
       const sequences = macros.map((expression) => {

--- a/src/store/macrosSlice.ts
+++ b/src/store/macrosSlice.ts
@@ -9,6 +9,7 @@ import {
 } from 'src/utils/macro-api/macro-api.common';
 import {RawKeycodeSequence} from 'src/utils/macro-api/types';
 import type {ConnectedDevice} from '../types/types';
+import {getSelectedKeyboardApi} from './devicesSlice';
 import type {AppThunk, RootState} from './index';
 
 export type MacrosState = {
@@ -56,13 +57,14 @@ export default macrosSlice.reducer;
 
 export const loadMacros =
   (connectedDevice: ConnectedDevice): AppThunk =>
-  async (dispatch) => {
-    const {path, protocol} = connectedDevice;
+  async (dispatch, getState) => {
+    const {protocol} = connectedDevice;
     if (protocol < 8) {
       dispatch(setMacrosNotSupported());
     } else {
       try {
-        const api = new KeyboardAPI(path);
+        const state = getState();
+        const api = getSelectedKeyboardApi(state) as KeyboardAPI;
         const macroApi = getMacroAPI(protocol, api);
         if (macroApi) {
           const sequences = await macroApi.readRawKeycodeSequences();
@@ -77,9 +79,10 @@ export const loadMacros =
 
 export const saveMacros =
   (connectedDevice: ConnectedDevice, macros: string[]): AppThunk =>
-  async (dispatch) => {
-    const {path, protocol} = connectedDevice;
-    const api = new KeyboardAPI(path);
+  async (dispatch, getState) => {
+    const state = getState();
+    const api = getSelectedKeyboardApi(state) as KeyboardAPI;
+    const {protocol} = connectedDevice;
     const macroApi = getMacroAPI(protocol, api);
     if (macroApi) {
       const sequences = macros.map((expression) => {

--- a/src/store/menusSlice.ts
+++ b/src/store/menusSlice.ts
@@ -12,7 +12,7 @@ import {getSelectedDefinition} from './definitionsSlice';
 import {
   getSelectedConnectedDevice,
   getSelectedDevicePath,
-  getSelectedKeyboardApi,
+  getSelectedKeyboardAPI,
 } from './devicesSlice';
 import {
   makeCustomMenu,
@@ -95,7 +95,7 @@ export const updateCustomMenuValue =
       }),
     );
 
-    const api = getSelectedKeyboardApi(state) as KeyboardAPI;
+    const api = getSelectedKeyboardAPI(state) as KeyboardAPI;
     api.setCustomMenuValue(...rest.slice(0));
 
     const channel = rest[0];
@@ -118,7 +118,7 @@ export const updateV3MenuData =
   async (dispatch, getState) => {
     const state = getState();
     const definition = getSelectedDefinition(state);
-    const api = getSelectedKeyboardApi(state) as KeyboardAPI;
+    const api = getSelectedKeyboardAPI(state) as KeyboardAPI;
 
     if (!isVIADefinitionV3(definition)) {
       throw new Error('V3 menus are only compatible with V3 VIA definitions.');

--- a/src/store/menusSlice.ts
+++ b/src/store/menusSlice.ts
@@ -12,6 +12,7 @@ import {getSelectedDefinition} from './definitionsSlice';
 import {
   getSelectedConnectedDevice,
   getSelectedDevicePath,
+  getSelectedKeyboardApi,
 } from './devicesSlice';
 import {
   makeCustomMenu,
@@ -94,7 +95,7 @@ export const updateCustomMenuValue =
       }),
     );
 
-    const api = new KeyboardAPI(path);
+    const api = getSelectedKeyboardApi(state) as KeyboardAPI;
     api.setCustomMenuValue(...rest.slice(0));
 
     const channel = rest[0];
@@ -117,6 +118,7 @@ export const updateV3MenuData =
   async (dispatch, getState) => {
     const state = getState();
     const definition = getSelectedDefinition(state);
+    const api = getSelectedKeyboardApi(state) as KeyboardAPI;
 
     if (!isVIADefinitionV3(definition)) {
       throw new Error('V3 menus are only compatible with V3 VIA definitions.');
@@ -126,8 +128,6 @@ export const updateV3MenuData =
     const {protocol, path} = connectedDevice;
 
     if (commands.length !== 0 && protocol >= 11) {
-      const api = new KeyboardAPI(path);
-
       let props = {} as CustomMenuData;
       const commandPromises = commands.map(([name, channelId, ...command]) => ({
         command: name,

--- a/src/store/menusSlice.ts
+++ b/src/store/menusSlice.ts
@@ -86,15 +86,15 @@ export const updateCustomMenuValue =
       ...menuData,
       [command]: [...rest.slice(commands[command].length)],
     };
-    const {device} = connectedDevice;
+    const {path} = connectedDevice;
     dispatch(
       updateSelectedCustomMenuData({
         menuData: data,
-        devicePath: device.path,
+        devicePath: path,
       }),
     );
 
-    const api = new KeyboardAPI(device);
+    const api = new KeyboardAPI(path);
     api.setCustomMenuValue(...rest.slice(0));
 
     const channel = rest[0];
@@ -123,10 +123,10 @@ export const updateV3MenuData =
     }
     const menus = getV3Menus(state);
     const commands = menus.flatMap(extractCommands);
-    const {protocol, device} = connectedDevice;
+    const {protocol, path} = connectedDevice;
 
     if (commands.length !== 0 && protocol >= 11) {
-      const api = new KeyboardAPI(device);
+      const api = new KeyboardAPI(path);
 
       let props = {} as CustomMenuData;
       const commandPromises = commands.map(([name, channelId, ...command]) => ({
@@ -162,7 +162,7 @@ export const updateV3MenuData =
 
       dispatch(
         updateSelectedCustomMenuData({
-          devicePath: device.path,
+          devicePath: path,
           menuData: {
             ...props,
           },

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -45,7 +45,6 @@ export type WebVIADevice = Device & {
 };
 
 export type ConnectedDevice = {
-  api: KeyboardAPI;
   device: Device;
   vendorProductId: number;
   protocol: number;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -100,3 +100,5 @@ export type DefinitionIndex = Pick<
   supportedVendorProductIdMap: VendorProductIdMap;
   hash: string;
 };
+
+export type EncoderBehavior = [number, number, number];

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,4 +1,3 @@
-import type {KeyboardAPI} from '../utils/keyboard-api';
 import type {
   DefinitionVersion,
   KeyboardDefinitionIndex,
@@ -45,7 +44,9 @@ export type WebVIADevice = Device & {
 };
 
 export type ConnectedDevice = {
-  device: Device;
+  path: string;
+  productId: number;
+  vendorId: number;
   vendorProductId: number;
   protocol: number;
   requiredDefinitionVersion: DefinitionVersion;

--- a/src/utils/device-store.ts
+++ b/src/utils/device-store.ts
@@ -12,6 +12,7 @@ import type {
   VendorProductIdMap,
   Settings,
   Device,
+  ConnectedDevice,
 } from '../types/types';
 import {getVendorProductId} from './hid-keyboards';
 
@@ -102,7 +103,7 @@ export async function syncStore(): Promise<DefinitionIndex> {
 export const getMissingDefinition = async <
   K extends keyof DefinitionVersionMap,
 >(
-  device: Device,
+  device: ConnectedDevice,
   version: K,
 ): Promise<[DefinitionVersionMap[K], K]> => {
   const vpid = getVendorProductId(device.vendorId, device.productId);

--- a/src/utils/hid-keyboards.ts
+++ b/src/utils/hid-keyboards.ts
@@ -41,7 +41,7 @@ const idExists = ({productId, vendorId}: Device, vpidMap: VendorProductIdMap) =>
 
 export const getRecognisedDevices = async (vpidMap: VendorProductIdMap) => {
   const usbDevices = await scanDevices();
-  return usbDevices.filter((device: Device) => {
+  return usbDevices.filter((device) => {
     const validVendorProduct = idExists(device, vpidMap);
     const validInterface = isValidInterface(device);
     // attempt connection

--- a/src/utils/keyboard-api.ts
+++ b/src/utils/keyboard-api.ts
@@ -77,7 +77,7 @@ export const PROTOCOL_GAMMA = 9;
 export const BACKLIGHT_PROTOCOL_NONE = 0;
 export const BACKLIGHT_PROTOCOL_WILBA = 1;
 
-const cache: {[addr: string]: {device: Device; hid: any}} = {};
+const cache: {[addr: string]: {hid: any}} = {};
 
 const eqArr = <T>(arr1: T[], arr2: T[]) => {
   if (arr1.length !== arr2.length) {
@@ -124,7 +124,7 @@ const globalCommandQueue: {
 
 export const canConnect = (device: Device) => {
   try {
-    initKeyboardAPI(device);
+    new KeyboardAPI(device.path);
     return true;
   } catch (e) {
     console.error('Skipped ', device, e);
@@ -132,25 +132,15 @@ export const canConnect = (device: Device) => {
   }
 };
 
-const initKeyboardAPI = (device: Device) => {
-  return new KeyboardAPI(device);
-};
-
 export class KeyboardAPI {
   kbAddr: HIDAddress;
 
-  constructor(device: Device) {
-    const {path} = device;
+  constructor(path: string) {
     this.kbAddr = path;
     if (!cache[path]) {
-      cache[path] = {device, hid: initAndConnectDevice(device)};
-    } else {
-      cache[path] = {...cache[path], device};
+      const device = initAndConnectDevice({path});
+      cache[path] = {hid: device};
     }
-  }
-
-  getDevice() {
-    return cache[this.kbAddr].device;
   }
 
   refresh(kbAddr: HIDAddress) {

--- a/src/utils/keyboard-api.ts
+++ b/src/utils/keyboard-api.ts
@@ -151,7 +151,7 @@ export class KeyboardAPI {
     };
   }
 
-  async getByteBuffer(): Promise<number[]> {
+  async getByteBuffer(): Promise<Uint8Array> {
     return this.getHID().readP();
   }
 
@@ -309,7 +309,7 @@ export class KeyboardAPI {
   ): Promise<number[]> {
     const bytes = [command];
     const res = await this.hidCommand(GET_KEYBOARD_VALUE, bytes);
-    return Array.from(res.slice(2, 2 + resultLength));
+    return res.slice(2, 2 + resultLength);
   }
 
   async setKeyboardValue(command: KeyboardValue, ...rest: number[]) {
@@ -339,7 +339,7 @@ export class KeyboardAPI {
 
   async getCustomMenuValue(commandBytes: number[]): Promise<number[]> {
     const res = await this.hidCommand(CUSTOM_MENU_GET_VALUE, commandBytes);
-    return Array.from(res.slice(0 + commandBytes.length));
+    return res.slice(0 + commandBytes.length);
   }
 
   async setCustomMenuValue(...args: number[]): Promise<void> {
@@ -379,7 +379,7 @@ export class KeyboardAPI {
   ): Promise<number[]> {
     const bytes = [command];
     const res = await this.hidCommand(BACKLIGHT_CONFIG_GET_VALUE, bytes);
-    return Array.from(res.slice(2, 2 + resultLength));
+    return res.slice(2, 2 + resultLength);
   }
 
   async setBacklightValue(command: LightingValue, ...rest: number[]) {
@@ -494,7 +494,7 @@ export class KeyboardAPI {
       );
     }
     const allBytes = await Promise.all(bytesP);
-    return allBytes.flatMap((bytes) => Array.from(bytes.slice(4)));
+    return allBytes.flatMap((bytes) => bytes.slice(4));
   }
 
   // From protocol: id_dynamic_keymap_macro_set_buffer <offset> <size> <data>
@@ -576,7 +576,7 @@ export class KeyboardAPI {
   async hidCommand(
     command: Command,
     bytes: Array<number> = [],
-  ): Promise<Uint8Array> {
+  ): Promise<number[]> {
     return new Promise((res, rej) => {
       this.commandQueueWrapper.commandQueue.push({
         res,
@@ -634,7 +634,7 @@ export class KeyboardAPI {
       this.refresh(kbAddr);
       this.getHID().write(paddedArray);
     }
-    const buffer = await this.getByteBuffer();
+    const buffer = Array.from(await this.getByteBuffer());
     const bufferCommandBytes = buffer.slice(0, commandBytes.length - 1);
     logCommand(this.kbAddr, commandBytes, buffer);
     if (!eqArr(commandBytes.slice(1), bufferCommandBytes)) {

--- a/src/utils/keyboard-api.ts
+++ b/src/utils/keyboard-api.ts
@@ -188,9 +188,8 @@ export class KeyboardAPI {
       const [, count] = await this.hidCommand(DYNAMIC_KEYMAP_GET_LAYER_COUNT);
       return count;
     }
-    if (version === PROTOCOL_ALPHA) {
-      return 4;
-    }
+
+    return 4;
   }
 
   async readRawMatrix(matrix: MatrixInfo, layer: number): Promise<Keymap> {
@@ -310,7 +309,7 @@ export class KeyboardAPI {
   ): Promise<number[]> {
     const bytes = [command];
     const res = await this.hidCommand(GET_KEYBOARD_VALUE, bytes);
-    return res.slice(2, 2 + resultLength);
+    return Array.from(res.slice(2, 2 + resultLength));
   }
 
   async setKeyboardValue(command: KeyboardValue, ...rest: number[]) {
@@ -324,10 +323,7 @@ export class KeyboardAPI {
     isClockwise: boolean,
   ): Promise<number> {
     const bytes = [layer, id, +isClockwise];
-    const res: number[] = await this.hidCommand(
-      DYNAMIC_KEYMAP_GET_ENCODER,
-      bytes,
-    );
+    const res = await this.hidCommand(DYNAMIC_KEYMAP_GET_ENCODER, bytes);
     return shiftTo16Bit([res[4], res[5]]);
   }
 
@@ -343,7 +339,7 @@ export class KeyboardAPI {
 
   async getCustomMenuValue(commandBytes: number[]): Promise<number[]> {
     const res = await this.hidCommand(CUSTOM_MENU_GET_VALUE, commandBytes);
-    return res.slice(0 + commandBytes.length);
+    return Array.from(res.slice(0 + commandBytes.length));
   }
 
   async setCustomMenuValue(...args: number[]): Promise<void> {
@@ -383,7 +379,7 @@ export class KeyboardAPI {
   ): Promise<number[]> {
     const bytes = [command];
     const res = await this.hidCommand(BACKLIGHT_CONFIG_GET_VALUE, bytes);
-    return res.slice(2, 2 + resultLength);
+    return Array.from(res.slice(2, 2 + resultLength));
   }
 
   async setBacklightValue(command: LightingValue, ...rest: number[]) {
@@ -577,7 +573,10 @@ export class KeyboardAPI {
     });
   }
 
-  async hidCommand(command: Command, bytes: Array<number> = []): Promise<any> {
+  async hidCommand(
+    command: Command,
+    bytes: Array<number> = [],
+  ): Promise<Uint8Array> {
     return new Promise((res, rej) => {
       this.commandQueueWrapper.commandQueue.push({
         res,

--- a/src/utils/usb-hid.ts
+++ b/src/utils/usb-hid.ts
@@ -1,14 +1,15 @@
 import {HID} from '../shims/node-hid';
 import {usbDetect} from '../shims/usb-detection';
-import type {Device} from '../types/types';
+import type {Device, WebVIADevice} from '../types/types';
 
 export {HID} from '../shims/node-hid';
 export {usbDetect} from '../shims/usb-detection';
 
-export async function scanDevices(): Promise<Device[]> {
+export async function scanDevices(): Promise<WebVIADevice[]> {
   return HID.devices();
 }
 
+// TODO: fix typing. This actually returns a HID object, but it complains if you type it as such.
 export function initAndConnectDevice({path}: Pick<Device, 'path'>): Device {
   const device = new HID.HID(path);
   return device;

--- a/src/utils/use-color-painter.tsx
+++ b/src/utils/use-color-painter.tsx
@@ -1,17 +1,20 @@
 import {ThreeEvent} from '@react-three/fiber';
 import {VIAKey} from '@the-via/reader';
 import {useCallback, useEffect, useState} from 'react';
-import {getSelectedConnectedDevice} from 'src/store/devicesSlice';
+import {
+  getSelectedConnectedDevice,
+  getSelectedKeyboardApi,
+} from 'src/store/devicesSlice';
 import {useAppSelector} from 'src/store/hooks';
 import {getSelectedCustomMenuData} from 'src/store/menusSlice';
 import {getHSVFrom256} from './color-math';
-import {KeyboardAPI} from './keyboard-api';
 
 export const useColorPainter = (
   keys: VIAKey[],
   selectedPaletteColor: [number, number],
 ) => {
   const selectedDevice = useAppSelector(getSelectedConnectedDevice);
+  const api = useAppSelector(getSelectedKeyboardApi);
   const customMenuData = useAppSelector(getSelectedCustomMenuData) || {
     __perKeyRGB: [],
   };
@@ -34,8 +37,7 @@ export const useColorPainter = (
 
   const onKeycapPointerHandler = useCallback(
     (evt: ThreeEvent<MouseEvent> | React.MouseEvent, idx: number) => {
-      if (evt.buttons === 1 && selectedDevice) {
-        const api = new KeyboardAPI(selectedDevice.path);
+      if (evt.buttons === 1 && api) {
         const hue = Math.round((selectedPaletteColor[0] * 255) / 360);
         const sat = Math.round(selectedPaletteColor[1] * 255);
         const ledIndex = keys[idx].li;

--- a/src/utils/use-color-painter.tsx
+++ b/src/utils/use-color-painter.tsx
@@ -35,7 +35,7 @@ export const useColorPainter = (
   const onKeycapPointerHandler = useCallback(
     (evt: ThreeEvent<MouseEvent> | React.MouseEvent, idx: number) => {
       if (evt.buttons === 1 && selectedDevice) {
-        const api = new KeyboardAPI(selectedDevice.device);
+        const api = new KeyboardAPI(selectedDevice.path);
         const hue = Math.round((selectedPaletteColor[0] * 255) / 360);
         const sat = Math.round(selectedPaletteColor[1] * 255);
         const ledIndex = keys[idx].li;

--- a/src/utils/use-color-painter.tsx
+++ b/src/utils/use-color-painter.tsx
@@ -5,16 +5,18 @@ import {getSelectedConnectedDevice} from 'src/store/devicesSlice';
 import {useAppSelector} from 'src/store/hooks';
 import {getSelectedCustomMenuData} from 'src/store/menusSlice';
 import {getHSVFrom256} from './color-math';
+import {KeyboardAPI} from './keyboard-api';
 
 export const useColorPainter = (
   keys: VIAKey[],
   selectedPaletteColor: [number, number],
 ) => {
-  const device = useAppSelector(getSelectedConnectedDevice);
+  const selectedDevice = useAppSelector(getSelectedConnectedDevice);
   const customMenuData = useAppSelector(getSelectedCustomMenuData) || {
     __perKeyRGB: [],
   };
   const [keyColors, setKeyColors] = useState<number[][]>([]);
+
   useEffect(() => {
     const perKeyRGB = (customMenuData as any).__perKeyRGB ?? [];
     const ledIndices = keys.find((k) => 'li' in k)
@@ -32,13 +34,14 @@ export const useColorPainter = (
 
   const onKeycapPointerHandler = useCallback(
     (evt: ThreeEvent<MouseEvent> | React.MouseEvent, idx: number) => {
-      if (evt.buttons === 1 && device) {
+      if (evt.buttons === 1 && selectedDevice) {
+        const api = new KeyboardAPI(selectedDevice.device);
         const hue = Math.round((selectedPaletteColor[0] * 255) / 360);
         const sat = Math.round(selectedPaletteColor[1] * 255);
         const ledIndex = keys[idx].li;
         if (ledIndex !== undefined) {
-          device.api.setPerKeyRGBMatrix(ledIndex, hue, sat);
-          device.api.commitCustomMenu(0);
+          api.setPerKeyRGBMatrix(ledIndex, hue, sat);
+          api.commitCustomMenu(0);
           setKeyColors((colors) => {
             colors[idx] = selectedPaletteColor;
             return [...colors];
@@ -46,7 +49,7 @@ export const useColorPainter = (
         }
       }
     },
-    [setKeyColors, selectedPaletteColor, keys, device],
+    [setKeyColors, selectedPaletteColor, keys, selectedDevice],
   );
 
   return {

--- a/src/utils/use-color-painter.tsx
+++ b/src/utils/use-color-painter.tsx
@@ -3,7 +3,7 @@ import {VIAKey} from '@the-via/reader';
 import {useCallback, useEffect, useState} from 'react';
 import {
   getSelectedConnectedDevice,
-  getSelectedKeyboardApi,
+  getSelectedKeyboardAPI,
 } from 'src/store/devicesSlice';
 import {useAppSelector} from 'src/store/hooks';
 import {getSelectedCustomMenuData} from 'src/store/menusSlice';
@@ -14,7 +14,7 @@ export const useColorPainter = (
   selectedPaletteColor: [number, number],
 ) => {
   const selectedDevice = useAppSelector(getSelectedConnectedDevice);
-  const api = useAppSelector(getSelectedKeyboardApi);
+  const api = useAppSelector(getSelectedKeyboardAPI);
   const customMenuData = useAppSelector(getSelectedCustomMenuData) || {
     __perKeyRGB: [],
   };


### PR DESCRIPTION
This change attempts to remove all non-serialisable data from the redux store.

This should make the redux store more performant and reliable (and rehydratable if we want to). It also removes a bunch of errors from the logs. 