### PR TITLE
Add device indication

### DIFF
--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -176,14 +176,14 @@ export const Home: React.VFC<HomeProps> = (props) => {
         api.timeout(i === 0 ? 0 : delay);
         api.setRGBMode(newVal);
         api.timeout(delay);
-        api.setRGBMode(val);
+        await api.setRGBMode(val);
       }
     }
 
     if (isVIADefinitionV3(selectedDefinition)) {
       for (let i = 0; i < 6; i++) {
         api.timeout(i === 0 ? 0 : delay);
-        api.setKeyboardValue(KeyboardValue.DEVICE_INDICATION, i);
+        await api.setKeyboardValue(KeyboardValue.DEVICE_INDICATION, i);
       }
     }
   };

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -5,6 +5,7 @@ import {startMonitoring, usbDetect} from '../utils/usb-hid';
 import {
   getLightingDefinition,
   isVIADefinitionV2,
+  isVIADefinitionV3,
   LightingValue,
 } from '@the-via/reader';
 import {
@@ -34,6 +35,7 @@ import {
 import {getNextKey} from 'src/utils/keyboard-rendering';
 import {mapEvtToKeycode} from 'src/utils/key-event';
 import {OVERRIDE_HID_CHECK} from 'src/utils/override';
+import {KeyboardValue} from 'src/utils/keyboard-api';
 
 const ErrorHome = styled.div`
   background: var(--bg_gradient);
@@ -156,35 +158,33 @@ export const Home: React.VFC<HomeProps> = (props) => {
   };
 
   const toggleLights = async () => {
-    if (!api) {
+    if (!api || !selectedDefinition) {
       return;
     }
 
-    // TODO: Some sort of toggling lights on v3 firmware
-    if (!isVIADefinitionV2(selectedDefinition)) {
-      return;
-    }
+    const delay = 200;
 
     if (
-      api &&
-      selectedDefinition &&
+      isVIADefinitionV2(selectedDefinition) &&
       getLightingDefinition(
         selectedDefinition.lighting,
       ).supportedLightingValues.includes(LightingValue.BACKLIGHT_EFFECT)
     ) {
       const val = await api.getRGBMode();
-      const newVal =
-        val !== 0
-          ? 0
-          : getLightingDefinition(selectedDefinition.lighting).effects.length -
-            1;
-      api.setRGBMode(newVal);
-      api.timeout(200);
-      api.setRGBMode(val);
-      api.timeout(200);
-      api.setRGBMode(newVal);
-      api.timeout(200);
-      await api.setRGBMode(val);
+      const newVal = val !== 0 ? 0 : 1;
+      for (let i = 0; i < 3; i++) {
+        api.timeout(i === 0 ? 0 : delay);
+        api.setRGBMode(newVal);
+        api.timeout(delay);
+        api.setRGBMode(val);
+      }
+    }
+
+    if (isVIADefinitionV3(selectedDefinition)) {
+      for (let i = 0; i < 6; i++) {
+        api.timeout(i === 0 ? 0 : delay);
+        api.setKeyboardValue(KeyboardValue.DEVICE_INDICATION, i);
+      }
     }
   };
 

--- a/src/utils/keyboard-api.ts
+++ b/src/utils/keyboard-api.ts
@@ -8,7 +8,7 @@ const VALID_PROTOCOL_VERSIONS = [1, 7, 8, 9, 10, 11];
 export const isValidProtocolVersion = (version: number) =>
   VALID_PROTOCOL_VERSIONS.includes(version);
 
-// Zeal60 API Command IDs
+// VIA Command IDs
 const COMMAND_START = 0x00; // This is really a HID Report ID
 const GET_PROTOCOL_VERSION = 0x01;
 const GET_KEYBOARD_VALUE = 0x02;
@@ -43,6 +43,8 @@ export enum KeyboardValue {
   UPTIME = 0x01,
   LAYOUT_OPTIONS = 0x02,
   SWITCH_MATRIX_STATE = 0x03,
+  FIRMWARE_VERSION = 0x04,
+  DEVICE_INDICATION = 0x05,
 }
 
 // RGB Backlight Value IDs


### PR DESCRIPTION
VIA V3 refactored backlight commands into custom menu commands. The `id_device_indication` command was added to the protocol as a generalized way to tell firmware that VIA is making it the selected device, so it can flash backlight, play a sound, etc. However, the code in VIA to send this command got lost somehow, probably hiding somewhere in a developer's git stash. Oh well.

This code is tested and working with V2 and V3 firmware.
