### PR TITLE
Fix window.showSaveFilePicker call

### DIFF
--- a/src/components/panes/configure-panes/save-load.tsx
+++ b/src/components/panes/configure-panes/save-load.tsx
@@ -114,7 +114,12 @@ export const Pane: FC = () => {
     try {
       const handle = await window.showSaveFilePicker({
         suggestedName,
-        types: [{accept: {'application/json': ['.layout.json']}}],
+        types: [
+          {
+            accept: {'application/json': ['.layout.json']},
+            description: 'JSON layout file',
+          },
+        ],
       });
       const encoderValues = await getEncoderValues();
       const saveFile: ViaSaveFile = {

--- a/src/components/panes/errors.tsx
+++ b/src/components/panes/errors.tsx
@@ -76,6 +76,12 @@ const saveKeyboardAPIErrors = async (errors: KeyboardAPIError[]) => {
   try {
     const handle = await window.showSaveFilePicker({
       suggestedName: 'VIA-keyboard-API-errors.csv',
+      types: [
+        {
+          accept: {'text/csv': ['.csv']},
+          description: 'CSV file',
+        },
+      ],
     });
     const headers = [`timestamp, vid, pid, commandName, command, response`];
     const data = errors.map(

--- a/src/components/three-fiber/export-scene.tsx
+++ b/src/components/three-fiber/export-scene.tsx
@@ -9,7 +9,12 @@ export const ExportScene = () => {
       try {
         const handle = await window.showSaveFilePicker({
           suggestedName: 'scene',
-          types: [{accept: {'application/octet-stream': ['.glb']}}],
+          types: [
+            {
+              accept: {'application/octet-stream': ['.glb']},
+              description: 'GLB file',
+            },
+          ],
         });
         const exporter = new GLTFExporter();
         const result = await new Promise((res) => {


### PR DESCRIPTION
Fixed "User cancelled save file request" error on saving a layout (Ubuntu 22.04, gnome, chrome).
May fix "Portal returned error: org.freedesktop.portal.Error.InvalidArgument: invalid filter: name is empty" error when saving a layout in AppImage (untested).
Fixed all calls to window.showSaveFilePicker in the same way, but tested only layout save.