### PR TITLE
Simplify window.showSaveFilePicker call

### DIFF
--- a/src/components/panes/configure-panes/save-load.tsx
+++ b/src/components/panes/configure-panes/save-load.tsx
@@ -110,16 +110,11 @@ export const Pane: FC = () => {
 
   const saveLayout = async () => {
     const {name, vendorProductId} = selectedDefinition;
-    const suggestedName = name.replace(/[^a-zA-Z0-9]/g, '_').toLowerCase();
+    const suggestedName =
+      name.replace(/[^a-zA-Z0-9]/g, '_').toLowerCase() + '.layout.json';
     try {
       const handle = await window.showSaveFilePicker({
         suggestedName,
-        types: [
-          {
-            accept: {'application/json': ['.layout.json']},
-            description: 'JSON layout file',
-          },
-        ],
       });
       const encoderValues = await getEncoderValues();
       const saveFile: ViaSaveFile = {

--- a/src/components/panes/errors.tsx
+++ b/src/components/panes/errors.tsx
@@ -121,12 +121,6 @@ async function saveErrors<T>(
   try {
     const handle = await window.showSaveFilePicker({
       suggestedName: `${fileName}.csv`,
-      types: [
-        {
-          accept: {'text/csv': ['.csv']},
-          description: 'CSV file',
-        },
-      ],
     });
     const csvHeaders = [headers.join(', ')];
     const data = errors.map(printRow);

--- a/src/components/three-fiber/export-scene.tsx
+++ b/src/components/three-fiber/export-scene.tsx
@@ -8,13 +8,7 @@ export const ExportScene = () => {
     if (state) {
       try {
         const handle = await window.showSaveFilePicker({
-          suggestedName: 'scene',
-          types: [
-            {
-              accept: {'application/octet-stream': ['.glb']},
-              description: 'GLB file',
-            },
-          ],
+          suggestedName: 'scene.glb',
         });
         const exporter = new GLTFExporter();
         const result = await new Promise((res) => {


### PR DESCRIPTION
Workaround for window.showSaveFilePicker call.
Closes https://github.com/the-via/app/issues/144
Closes https://github.com/the-via/releases/issues/252

Fixed all calls to window.showSaveFilePicker in the same way, but tested only layout save.
Tested on MacBook (arm, Chrome 111), Ubuntu 22.04 (intel, Chrome 111).

This is a workaround for the Chrome bug (any actions in JS should not crash the browser).
Related chromium bug (or similar): https://bugs.chromium.org/p/chromium/issues/detail?id=1424361