### PR TITLE
Add timeout for custom menu commits

### DIFF
--- a/src/store/menusSlice.ts
+++ b/src/store/menusSlice.ts
@@ -101,10 +101,10 @@ export const updateCustomMenuValue =
 
     const channel = rest[0];
     
-    // Delete existing menu commit timeout if it exists
+    // Delete any existing menu commit timeouts
     clearTimeout(customMenuCommitTimeouts[channel]);
 
-    // Generate timeout for commiting the custom menu
+    // Create and store timeout for commiting the custom menu
     const customMenuTimeoutMs: number = 250;
     customMenuCommitTimeouts[channel] = setTimeout(() => {
       api.commitCustomMenu(channel);


### PR DESCRIPTION
Hello while implementing  a custom menu for my device I found what appears to be a disagreement between the documentation and behaviour of VIA.

The [VIA docs](https://www.caniusevia.com/docs/custom_ui#saving-values) currently state the following: 

> The id_custom_save command is sent after one or more id_custom_set_value commands have been sent, and after a small delay. It is used to allow the firmware to defer writing to EEPROM and respond to set value commands quickly.

However the current VIA codebase will push a custom menu save command for every custom menu set it does, this is not ideal for the EEPROM as such it would be best in my opinion to defer writing to the EEPROM until we are sure that the user has settled on a value.

To fix this I have offloaded the sending of a custom menu save command to a function that is executed only once 250ms has passed without any custom menu updates. 

I am very happy to update and change the solution chosen as there are of course multiple ways to proceed with this problem, including moving the tackling of EEPROM save timing to firmware.

I was also unsure whether or not I should open an associated issue to link to this PR, let me know if that would be useful.