### PR TITLE
Add RGB Hexadecimal text input to colour picker 

### DIFF
--- a/src/components/inputs/color-picker.tsx
+++ b/src/components/inputs/color-picker.tsx
@@ -257,36 +257,7 @@ export class ColorPicker extends Component<Props, State> {
 
     return [r, g, b];
   }
-
-  // hexToHs(hex: string): {hue: number; sat: number} {
-  //   const r = parseInt(hex.substring(0, 2), 16) / 255;
-  //   const g = parseInt(hex.substring(2, 2), 16) / 255;
-  //   const b = parseInt(hex.substring(4, 2), 16) / 255;
-  //   const max = Math.max(r, g, b);
-  //   const min = Math.min(r, g, b);
-  //   let hue = 0;
-  //   if (max === min) {
-  //     hue = 0;
-  //   } else {
-  //     const diff = max - min;
-  //     switch (max) {
-  //       case r:
-  //         hue = ((g - b) / diff + (g < b ? 6 : 0)) * 60;
-  //         break;
-  //       case g:
-  //         hue = ((b - r) / diff + 2) * 60;
-  //         break;
-  //       case b:
-  //         hue = ((r - g) / diff + 4) * 60;
-  //         break;
-  //       default:
-  //         break;
-  //     }
-  //   }
-  //   const sat = max === 0 ? 0 : (max - min) / max;
-  //   return {hue, sat};
-  // }
-
+  
   getRGB({hue, sat}: {hue: number; sat: number}) {
     const [r, g, b] = this.hsToRgb({hue, sat});
     return `rgba(${r},${g},${b},1)`;

--- a/src/components/inputs/color-picker.tsx
+++ b/src/components/inputs/color-picker.tsx
@@ -2,11 +2,12 @@ import React, {Component, KeyboardEventHandler} from 'react';
 import styled from 'styled-components';
 
 import {
-  getRGBPrime,
   toDegrees,
   calcRadialHue,
   calcRadialMagnitude,
   getHSV,
+  getRGB,
+  getHex,
 } from '../../utils/color-math';
 
 type Color = {
@@ -155,7 +156,7 @@ export class ColorPicker extends Component<Props, State> {
     lensTransform: '',
     showPicker: false,
     offset: [5, 5] as [number, number],
-    hexColorCode: this.getHex(this.props.color),
+    hexColorCode: getHex(this.props.color),
   };
 
   componentWillUnmount() {
@@ -214,7 +215,7 @@ export class ColorPicker extends Component<Props, State> {
 
       const offset = [offsetX, offsetY] as [number, number];
       const {hue, sat} = this.getLinearHueSat(offset);
-      const hexColorCode = this.getHex(this.props.color);
+      const hexColorCode = getHex(this.props.color);
       this.props.setColor(Math.round(255 * (hue / 360)), Math.round(255 * sat));
       this.setState({
         lensTransform,
@@ -243,32 +244,6 @@ export class ColorPicker extends Component<Props, State> {
     }
   };
 
-  hsToRgb({hue, sat}: {hue: number; sat: number}) {
-    sat = sat / 255;
-    hue = Math.round(360 * hue) / 255;
-    const c = sat;
-    const x = c * (1 - Math.abs(((hue / 60) % 2) - 1));
-    const m = 1 - c;
-    const [r, g, b] = getRGBPrime(hue, c, x).map((n) =>
-      Math.round(255 * (m + n)),
-    );
-
-    return [r, g, b];
-  }
-
-  getRGB({hue, sat}: {hue: number; sat: number}) {
-    const [r, g, b] = this.hsToRgb({hue, sat});
-    return `rgba(${r},${g},${b},1)`;
-  }
-
-  getHex({hue, sat}: {hue: number; sat: number}) {
-    let [r, g, b] = this.hsToRgb({hue, sat}).map((x) => x.toString(16));
-    if (r.length == 1) r = '0' + r;
-    if (g.length == 1) g = '0' + g;
-    if (b.length == 1) b = '0' + b;
-    return '#' + r + g + b;
-  }
-
   onThumbnailClick = () => {
     if (this.props.onOpen) {
       this.props.onOpen();
@@ -295,7 +270,7 @@ export class ColorPicker extends Component<Props, State> {
       this.mouseDown = false;
       this.setState({
         showPicker: false,
-        hexColorCode: this.getHex(this.props.color),
+        hexColorCode: getHex(this.props.color),
       });
     } else if (
       this.mouseDown &&
@@ -322,7 +297,7 @@ export class ColorPicker extends Component<Props, State> {
   };
 
   handleHexBlur: React.ChangeEventHandler<HTMLInputElement> = (e) => {
-    this.setState({hexColorCode: this.getHex(this.props.color)});
+    this.setState({hexColorCode: getHex(this.props.color)});
   };
 
   handleHexSubmit: React.KeyboardEventHandler<HTMLInputElement> = (e) => {
@@ -339,12 +314,12 @@ export class ColorPicker extends Component<Props, State> {
         const [h, s] = getHSV(hexString);
         this.props.setColor(Math.round(255 * (h / 360)), Math.round(255 * s));
       }
-      this.setState({hexColorCode: this.getHex(this.props.color)});
+      this.setState({hexColorCode: getHex(this.props.color)});
     }
   };
 
   render() {
-    const color = this.getRGB(this.props.color);
+    const color = getRGB(this.props.color);
     const {isSelected = false} = this.props;
     const {offset} = this.state;
 
@@ -378,9 +353,7 @@ export class ColorPicker extends Component<Props, State> {
                   onKeyDown={this.handleHexSubmit}
                 />
               </ColorHexContainer>
-              <ColorPreview
-                style={{background: this.getRGB(this.props.color)}}
-              />
+              <ColorPreview style={{background: getRGB(this.props.color)}} />
               <Container>
                 <ColorOuter
                   onMouseDown={this.onMouseDown}

--- a/src/components/inputs/color-picker.tsx
+++ b/src/components/inputs/color-picker.tsx
@@ -108,7 +108,7 @@ const PickerContainer = styled.div`
     border-bottom-color: transparent;
     border-right-color: transparent;
     right: -22px;
-    top: 50px;
+    top: 66px;
   }
 `;
 

--- a/src/components/inputs/color-picker.tsx
+++ b/src/components/inputs/color-picker.tsx
@@ -126,6 +126,7 @@ const ColorHexContainer = styled.div`
   height: 32px;
   line-height: 32px;
   text-align: center;
+  background: var(--bg_menu);
 `;
 
 const ColorHexInput = styled.input`
@@ -141,9 +142,6 @@ const ColorHexInput = styled.input`
     outline: none;
     color: var(--color_accent);
     border-color: var(--color_accent);
-  }
-  &::placeholder {
-    color: var(--bg_control);
   }
 `;
 
@@ -257,7 +255,7 @@ export class ColorPicker extends Component<Props, State> {
 
     return [r, g, b];
   }
-  
+
   getRGB({hue, sat}: {hue: number; sat: number}) {
     const [r, g, b] = this.hsToRgb({hue, sat});
     return `rgba(${r},${g},${b},1)`;

--- a/src/utils/color-math.ts
+++ b/src/utils/color-math.ts
@@ -178,3 +178,24 @@ export function calcRadialMagnitude(x: number, y: number) {
     return x > 200 ? (x - 200) / 200 : (200 - x) / 200;
   }
 }
+
+export function hsToRgb({hue, sat}: {hue: number; sat: number}) {
+  sat = sat / 255;
+  hue = Math.round(360 * hue) / 255;
+  const c = sat;
+  const x = c * (1 - Math.abs(((hue / 60) % 2) - 1));
+  const m = 1 - c;
+  const [r, g, b] = getRGBPrime(hue, c, x).map((n) =>
+    Math.round(255 * (m + n)),
+  );
+
+  return [r, g, b];
+}
+
+export function getHex({hue, sat}: {hue: number; sat: number}) {
+  let [r, g, b] = hsToRgb({hue, sat}).map((x) => x.toString(16));
+  if (r.length == 1) r = '0' + r;
+  if (g.length == 1) g = '0' + g;
+  if (b.length == 1) b = '0' + b;
+  return '#' + r + g + b;
+}


### PR DESCRIPTION
![image](https://github.com/the-via/app/assets/30512204/6c912dcf-bd49-456f-a1a6-91a6e2cec01d)

- Adds a text input above the colour picker.
- If you drag the mouse to pick a colour, the hex code updates.
- Hex code inputs is restricted to base16 chars.
- Pressing enter after typing or pasting a hex colour code chooses the same colour by hue and sat but with 100% luminance.
- Pressing enter without a valid 3 or 6 character hex colour code will do nothing
- Clicking out of the colour picker will reset the text box to match the selected colour

