### PR TITLE
Show the keycode in the tooltip

### DIFF
--- a/src/components/two-string/unit-key/keycap.tsx
+++ b/src/components/two-string/unit-key/keycap.tsx
@@ -301,6 +301,8 @@ export const Keycap: React.FC<TwoStringKeycapProps> = React.memo((props) => {
     idx,
     mode,
   ]);
+  const primaryTooltip = macroData || (label && label.tooltipLabel)
+  const secondaryTooltip = label?.keyCode
   return shouldRotate ? (
     <EncoderKey
       onClick={onClick}
@@ -405,10 +407,10 @@ export const Keycap: React.FC<TwoStringKeycapProps> = React.memo((props) => {
             <canvas ref={canvasRef} style={{}} />
           </CanvasContainer>
         </GlowContainer>
-        {(macroData || overflowsTexture) && (
+        {(macroData || overflowsTexture || (label?.tooltipLabel) || (label?.keyCode)) && (
           <TooltipContainer $rotate={rotation[2]}>
             <Keycap2DTooltip>
-              {macroData || (label && label.tooltipLabel)}
+              {primaryTooltip || secondaryTooltip}{secondaryTooltip && primaryTooltip && ` (${secondaryTooltip})`}
             </Keycap2DTooltip>
           </TooltipContainer>
         )}

--- a/src/utils/keyboard-rendering.ts
+++ b/src/utils/keyboard-rendering.ts
@@ -491,6 +491,8 @@ export const getLabel = (
     tooltipLabel = macroExpression || '';
   }
 
+  const keyCode = byteToKey[keycodeByte];
+
   if (isAlpha(label) || isNumpadNumber(label)) {
     return (
       label && {
@@ -499,6 +501,7 @@ export const getLabel = (
         key: (label || '') + (macroExpression || ''),
         size: size,
         offset: offset,
+        keyCode,
       }
     );
   } else if (isMultiLegend(label)) {
@@ -512,6 +515,7 @@ export const getLabel = (
         key: (label || '') + (macroExpression || ''),
         size: size,
         offset: getLabelOffsets(topLabel, bottomLabel),
+        keyCode,
       }
     );
   } else {
@@ -529,6 +533,7 @@ export const getLabel = (
       key: (label || '') + (macroExpression || ''),
       size: size,
       offset: offset,
+      keyCode,
     };
   }
 };


### PR DESCRIPTION
Show the keycode in the tooltip. If there would not have been a tooltip before, show the keycode. If there would have been a tooltip before, show that tooltip with the keycode after in parenthesis.

Examples:
![image](https://github.com/the-via/app/assets/8503756/51a8a501-f852-4019-8582-7cd7cf1b398c)
Very helpful if the key only has an icon!
![image](https://github.com/the-via/app/assets/8503756/2e383f60-4abc-4b06-a536-5cdf4189a6fe)

Not sure why in the second case, it's also showing the triangle. It didn't used to. Maybe someone can help me with that.

Fixes #105