### PR TITLE
Add key for each line in errors

### DIFF
--- a/src/components/panes/errors.tsx
+++ b/src/components/panes/errors.tsx
@@ -97,7 +97,7 @@ const AppErrors: React.FC<{}> = ({}) => {
             {timestamp}
             <ul>
               {error?.split('\n').map((line) => (
-                <li>{line}</li>
+                <li key={line}>{line}</li>
               ))}
             </ul>
             <ul>


### PR DESCRIPTION
React was yelling at me because this map didn't have a key. Since they're strings, lines of an error, I think they're fine as keys themselves - if the line is too long to be a good idea to use as a key, it probably is also too long to be displayed without truncation, so I'll assume both are going to be reasonable lengths.