### PR TITLE
Show tooltips for keys with a shortName

### DIFF
--- a/src/components/three-fiber/unit-key/keycap.tsx
+++ b/src/components/three-fiber/unit-key/keycap.tsx
@@ -463,7 +463,7 @@ export const Keycap: React.FC<ThreeFiberKeycapProps> = React.memo((props) => {
           />
         </AniMeshMaterial>
       </animated.mesh>
-      {(macroData || overflowsTexture) && (
+      {(macroData || overflowsTexture || (label && label.shortName)) && (
         <React.Suspense fallback={null}>
           <animated.group
             position={props.position}

--- a/src/components/two-string/unit-key/combo-keycap.tsx
+++ b/src/components/two-string/unit-key/combo-keycap.tsx
@@ -173,7 +173,9 @@ export const ComboKeycap = (props: any) => {
             ></TestOverlay>
           ) : null}
         </ComboKeyBoundingContainer>
-        {(props.macroData || props.overflowsTexture) && (
+        {(props.macroData ||
+          props.overflowsTexture ||
+          (props.lablel && props.label.shortName)) && (
           <TooltipContainer $rotate={props.rotation[2]}>
             <Keycap2DTooltip>
               {props.macroData || (props.label && props.label.tooltipLabel)}

--- a/src/components/two-string/unit-key/keycap.tsx
+++ b/src/components/two-string/unit-key/keycap.tsx
@@ -405,7 +405,7 @@ export const Keycap: React.FC<TwoStringKeycapProps> = React.memo((props) => {
             <canvas ref={canvasRef} style={{}} />
           </CanvasContainer>
         </GlowContainer>
-        {(macroData || overflowsTexture) && (
+        {(macroData || overflowsTexture || (label && label.shortName)) && (
           <TooltipContainer $rotate={rotation[2]}>
             <Keycap2DTooltip>
               {macroData || (label && label.tooltipLabel)}

--- a/src/utils/key.ts
+++ b/src/utils/key.ts
@@ -336,6 +336,16 @@ export function getShortNameForKeycode(keycode: IKeycode, size = 100) {
   return name;
 }
 
+export function byteHasShortname(
+  byte: number,
+  basicKeyToByte: Record<string, number>,
+  byteToKey: Record<number, string>,
+) {
+  const keycode = getCodeForByte(byte, basicKeyToByte, byteToKey);
+  const basicKeycode = keycodesList.find(({code}) => code === keycode);
+  return basicKeycode?.shortName;
+}
+
 export function getOtherMenu(
   basicKeyToByte: Record<string, number>,
 ): IKeycodeMenu {

--- a/src/utils/keyboard-rendering.ts
+++ b/src/utils/keyboard-rendering.ts
@@ -22,6 +22,7 @@ import {
   isArrowKey,
   isMacroKeycodeByte,
   getMacroKeycodeIndex,
+  byteHasShortname,
 } from './key';
 
 export const CSSVarObject = {
@@ -462,6 +463,7 @@ export const getLabel = (
 
   // Full name
   let tooltipLabel: string = '';
+  let shortName: string | undefined;
   if (
     isCustomKeycodeByte(keycodeByte, basicKeyToByte) &&
     selectedDefinition?.customKeycodes &&
@@ -477,12 +479,16 @@ export const getLabel = (
       selectedDefinition.customKeycodes[customKeycodeIdx] as IKeycode,
       700,
     );
+    shortName = (
+      selectedDefinition.customKeycodes[customKeycodeIdx] as IKeycode
+    ).shortName;
   } else if (keycodeByte) {
     label =
       getLabelForByte(keycodeByte, width * 100, basicKeyToByte, byteToKey) ??
       '';
     tooltipLabel =
       getLabelForByte(keycodeByte, 700, basicKeyToByte, byteToKey) ?? '';
+    shortName = byteHasShortname(keycodeByte, basicKeyToByte, byteToKey);
   }
   let macroExpression: string | undefined;
   if (isMacroKeycodeByte(keycodeByte, basicKeyToByte)) {
@@ -529,6 +535,7 @@ export const getLabel = (
       key: (label || '') + (macroExpression || ''),
       size: size,
       offset: offset,
+      shortName,
     };
   }
 };


### PR DESCRIPTION
Hi! This diff is just a suggestion, feel free to close if you like.

I noticed that tooltips are only being shown today, but only sometimes — for example, if a key name doesn't fit within the key cap.

It's not always intuitive (for a beginner like myself) to know what all of the short hand names map to. 

This diff just always shows tooltips for items that have a `shortName` specified in `src/utils/key.ts`. It's a bit weird because it's kind of a side-effect of having a shortName specified, but in turn it makes things a bit easier for when you're hovering over caps. 

There's ~318 keys in `src/utils/key.ts` and 44 of them specify a `shortName`.

![image](https://github.com/the-via/app/assets/424158/0c238353-8e45-4169-ab09-dfe50fc019e4)


