### PR TITLE
add 'button' support in custom menus

### DIFF
--- a/src/components/panes/configure-panes/custom/custom-control.tsx
+++ b/src/components/panes/configure-panes/custom/custom-control.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {PelpiKeycodeInput} from '../../../inputs/pelpi/keycode-input';
+import {AccentButton} from '../../../inputs/accent-button';
 import {AccentSlider} from '../../../inputs/accent-slider';
 import {AccentSelect} from '../../../inputs/accent-select';
 import {AccentRange} from '../../../inputs/accent-range';
@@ -78,6 +79,15 @@ const VIACustomControl = (props: VIACustomControlProps) => {
   const {content, type, options, value} = props as any;
   const [name, ...command] = content;
   switch (type) {
+    case 'button': {
+      return (
+        <AccentButton
+          onClick={() => 
+            props.updateValue(name, ...command, options)
+          }
+        >Click</AccentButton>
+      );
+    }
     case 'range': {
       return (
         <AccentRange

--- a/src/components/panes/configure-panes/custom/custom-control.tsx
+++ b/src/components/panes/configure-panes/custom/custom-control.tsx
@@ -80,10 +80,11 @@ const VIACustomControl = (props: VIACustomControlProps) => {
   const [name, ...command] = content;
   switch (type) {
     case 'button': {
+      const buttonOption: any[] = options || [1];
       return (
         <AccentButton
           onClick={() => 
-            props.updateValue(name, ...command, options)
+            props.updateValue(name, ...command, buttonOption[0])
           }
         >Click</AccentButton>
       );


### PR DESCRIPTION
Add button support to the custom menus

https://github.com/the-via/reader/pull/28 in the-via/reader is also required

![image](https://github.com/the-via/app/assets/17491233/6936502a-58d8-4aa6-81fa-d4049befd427)

Tested with Hayabusa with this configuration
```
"menus": [
  {
    "label": "Lighting",
    "content": [
      {
        "label": "Backlight",
        "content": [
          {
            "label": "Test Button",
            "type": "button",
            "options": [34],
            "content": [ "id_caps_lock_enable", 0, 1 ]
          }
        ]
      }
    ]
  }
],
```

Tested and working with 
https://github.com/Xelus22/qmk_firmware/commit/ca7f6629eb52687f2a4fb93bc6462a099de518d5