### PR TITLE
Use docker for building/running the via app

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+/node_modules
+/Dockerfile
+/docker-compose.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM node:21-alpine
+
+RUN apk update
+
+RUN apk upgrade
+
+RUN apk add jq xdg-utils
+
+WORKDIR /app
+
+COPY . .
+
+RUN sed -i -e 's/run dev/run dev -- --host/' package.json
+
+RUN npm install
+
+RUN npm run build:azure || true
+
+EXPOSE 5173
+
+CMD [ "npm", "start" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+# Run `docker-compose up` to build and run the via app in docker
+version: '3.9'
+services:
+  via:
+    build:
+      context: .
+      pull: true
+      dockerfile: Dockerfile
+      tags:
+        - via
+    stdin_open: true
+    tty: true
+    ports:
+      - "127.0.0.1:5173:5173"
+    depends_on: []


### PR DESCRIPTION
This might be useful for people that want to build and run the via app without having to install the dependencies directly on their local machine rather than just using the official web site.