### PR TITLE
Addition of explicit value of sliders

### DIFF
--- a/src/components/inputs/accent-range.tsx
+++ b/src/components/inputs/accent-range.tsx
@@ -1,28 +1,48 @@
-import React from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import styled from 'styled-components';
 
 const Container = styled.span`
-  display: inline-block;
+  display: flex;
+  align-items: center;
   line-height: initial;
   width: 200px;
 `;
 
-const SliderInput = styled.input.attrs({type: 'range'})<any>`
+const SliderInput = styled.input.attrs({type: 'range'})`
   accent-color: var(--color_accent);
   width: 100%;
+`;
+
+const ValueDisplay = styled.span`
+  margin-right: 10px;
 `;
 
 export const AccentRange: React.FC<
   Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange'> & {
     onChange: (x: number) => void;
   }
-> = (props) => (
-  <Container>
-    <SliderInput
-      {...props}
-      onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-        props.onChange && props.onChange(+e.target.value);
-      }}
-    />
-  </Container>
-);
+> = (props) => {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [sliderValue, setSliderValue] = useState(() => +inputRef.current?.value || 0);
+
+  useEffect(() => {
+    if (inputRef.current) {
+      setSliderValue(+inputRef.current.value);
+    }
+  }, [props.value]);
+
+  return (
+    <Container>
+      <ValueDisplay>{sliderValue}</ValueDisplay>
+      <SliderInput
+        ref={inputRef}
+        {...props}
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+          const value = +e.target.value;
+          setSliderValue(value);
+          props.onChange?.(value);
+        }}
+      />
+    </Container>
+  );
+};


### PR DESCRIPTION
This commit aims to provide precise visual feedback on the current value at which the slider is at.
This helps in case the slider is used for precise value input that benefits from a linear input method.

The value updates on the fly when the slider is moving and it's solid with the slider element when resizing the webpage view, to avoid it being wrongly rendered.

Here's a preview of the feature:
![image](https://github.com/the-via/app/assets/40441626/7acfc8f4-54cf-4f8e-893d-f3a367100452)
