### PR TITLE
proper error when loading layout with incorrect layer count

### DIFF
--- a/src/components/panes/configure-panes/save-load.tsx
+++ b/src/components/panes/configure-panes/save-load.tsx
@@ -174,6 +174,13 @@ export const Pane: FC = () => {
         return;
       }
 
+      if (saveFile.layers.length != rawLayers.length) {
+        setErrorMessage(
+          `Could not import layout: incorrect number of layers (got ${saveFile.layers.length}, expected ${rawLayers.length}).`,
+        );
+        return;
+      }
+
       if (
         saveFile.layers.findIndex(
           (layer, idx) => layer.length !== rawLayers[idx].keymap.length,


### PR DESCRIPTION
This PR add proper error handling when loaded layout provide a wrong number of layers. 