### PR TITLE
[Feature Dreft] Improving accessibility of some UI Components.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "via-app",
+  "name": "app",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/src/components/inputs/accent-button.tsx
+++ b/src/components/inputs/accent-button.tsx
@@ -36,6 +36,9 @@ export const AccentButton = styled(AccentButtonBase)`
   &:hover {
     filter: brightness(0.7);
   }
+  &:focus {
+    filter: brightness(0.7);
+  }
 `;
 export const AccentButtonLarge = styled(AccentButton)`
   font-size: 24px;

--- a/src/components/inputs/accent-slider.tsx
+++ b/src/components/inputs/accent-slider.tsx
@@ -43,6 +43,7 @@ const Slider = styled.span<{$ischecked?: boolean}>`
 
 type Props = {
   isChecked: boolean;
+  id:string
   onChange: (val: boolean) => void;
 };
 
@@ -70,6 +71,8 @@ export function AccentSlider(props: Props) {
     <Switch>
       <HiddenInput
         ref={ref}
+        role='switch'
+        id={props.id}
         type="checkbox"
         checked={isHiddenChecked}
         onChange={hiddenOnChange}

--- a/src/components/inputs/accent-upload-button.tsx
+++ b/src/components/inputs/accent-upload-button.tsx
@@ -5,6 +5,8 @@ type Props = {
   multiple?: boolean;
   inputRef?: React.MutableRefObject<HTMLInputElement | undefined>;
   children: string;
+  describedby?: string;
+  description?: string;
 };
 
 export function AccentUploadButton(props: Props) {
@@ -14,7 +16,7 @@ export function AccentUploadButton(props: Props) {
     (input.current as any).value = null;
   }
   return (
-    <AccentButton onClick={() => input.current && input.current.click()}>
+    <AccentButton aria-describedby={props.describedby} aria-description={props.description} onClick={() => input.current && input.current.click()}>
       {props.children}
       <input
         ref={input as any}

--- a/src/components/menus/global.tsx
+++ b/src/components/menus/global.tsx
@@ -40,7 +40,10 @@ export const UnconnectedGlobalMenu = () => {
         if (pane.key === 'debug' && !showDebugPane) return null;
         return (
           <Link key={pane.key} to={pane.path}>
-            <CategoryIconContainer $selected={pane.path === location}>
+            <CategoryIconContainer $selected={pane.path === location}
+            role='link'
+            tabIndex={0}
+            aria-current={pane.path === location ? "page" : "false"}>
               <FontAwesomeIcon size={'xl'} icon={pane.icon} />
               <CategoryMenuTooltip>{pane.title}</CategoryMenuTooltip>
             </CategoryIconContainer>

--- a/src/components/panes/configure-panes/save-load.tsx
+++ b/src/components/panes/configure-panes/save-load.tsx
@@ -247,15 +247,17 @@ export const Pane: FC = () => {
       <SaveLoadPane>
         <Container>
           <ControlRow>
-            <Label>Save Current Layout</Label>
+            <Label id='label_save'>Save Current Layout</Label>
             <Detail>
-              <AccentButton onClick={saveLayout}>Save</AccentButton>
+              <AccentButton onClick={saveLayout} aria-describedby='label_save'>Save</AccentButton>
             </Detail>
           </ControlRow>
           <ControlRow>
-            <Label>Load Saved Layout</Label>
+            <Label id="label_load">Load Saved Layout</Label>
             <Detail>
-              <AccentUploadButton onLoad={loadLayout}>Load</AccentUploadButton>
+              <AccentUploadButton 
+              describedby='label_load'
+              onLoad={loadLayout}>Load</AccentUploadButton>
             </Detail>
           </ControlRow>
           {errorMessage ? <ErrorMessage>{errorMessage}</ErrorMessage> : null}

--- a/src/components/panes/grid.tsx
+++ b/src/components/panes/grid.tsx
@@ -165,4 +165,7 @@ export const SubmenuRow = styled(Row)`
   color: ${(props) =>
     props.$selected ? 'var(--color_label-highlighted)' : 'var(--color_label)'};
   border-radius: 12px;
+  &:focus {
+    outline:auto;
+  }
 `;

--- a/src/components/panes/settings.tsx
+++ b/src/components/panes/settings.tsx
@@ -1,4 +1,4 @@
-import {useState} from 'react';
+import {useEffect, useRef, useState} from 'react';
 import {Pane} from './pane';
 import styled from 'styled-components';
 import {
@@ -87,12 +87,14 @@ export const Settings = () => {
   const renderModeDefaultValue = renderModeOptions.find(
     (opt) => opt.value === renderMode,
   );
+
   return (
     <Pane>
       <Grid style={{overflow: 'hidden'}}>
         <MenuCell style={{pointerEvents: 'all', borderTop: 'none'}}>
           <MenuContainer>
-            <Row $selected={true}>
+            <Row $selected={true}
+            >
               <IconContainer>
                 <FontAwesomeIcon icon={faToolbox} />
                 <MenuTooltip>General</MenuTooltip>
@@ -103,27 +105,30 @@ export const Settings = () => {
         <SpanOverflowCell style={{flex: 1, borderWidth: 0}}>
           <Container>
             <ControlRow>
-              <Label>Show Design tab</Label>
+              <Label htmlFor='show_design_tab'>Show Design tab</Label>
               <Detail>
                 <AccentSlider
+                  id='show_desing_tab'
                   onChange={() => dispatch(toggleCreatorMode())}
                   isChecked={showDesignTab}
                 />
               </Detail>
             </ControlRow>
             <ControlRow>
-              <Label>Fast Key Mapping</Label>
+              <Label htmlFor='fast_mapping'>Fast Key Mapping</Label>
               <Detail>
                 <AccentSlider
+                  id={"fast_mapping"}
                   onChange={() => dispatch(toggleFastRemap())}
                   isChecked={!disableFastRemap}
                 />
               </Detail>
             </ControlRow>
             <ControlRow>
-              <Label>Light Mode</Label>
+              <Label htmlFor="turn_on_light">Light Mode</Label>
               <Detail>
                 <AccentSlider
+                  id='turn_on_light'
                   onChange={() => dispatch(toggleThemeMode())}
                   isChecked={themeMode === 'light'}
                 />

--- a/src/components/panes/settings.tsx
+++ b/src/components/panes/settings.tsx
@@ -159,11 +159,12 @@ export const Settings = () => {
               </Detail>
             </ControlRow>
             <ControlRow>
-              <Label>Show Diagnostic Information</Label>
+              <Label htmlFor='diagonistic'>Show Diagnostic Information</Label>
 
               <Detail>
                 {selectedDevice ? (
                   <AccentSlider
+                    id='diagonistic'
                     onChange={() => setShowDiagnostics(!showDiagnostics)}
                     isChecked={showDiagnostics}
                   />

--- a/src/components/two-string/unit-key/keycap.tsx
+++ b/src/components/two-string/unit-key/keycap.tsx
@@ -301,6 +301,7 @@ export const Keycap: React.FC<TwoStringKeycapProps> = React.memo((props) => {
     idx,
     mode,
   ]);
+  
   return shouldRotate ? (
     <EncoderKey
       onClick={onClick}
@@ -349,10 +350,26 @@ export const Keycap: React.FC<TwoStringKeycapProps> = React.memo((props) => {
   ) : (
     <>
       <KeycapContainer
+        
+        role={"button"}
+        aria-disabled={disabled}
+        aria-label={`${macroData || ( label && (label.label ? label.label : label.bottomLabel ? `${label.bottomLabel} ${label.topLabel}` : label.tooltipLabel) )}`}
+        aria-pressed={selected}
+        tabIndex={disabled ? undefined : 0}
         onClick={onClick}
+        onKeyDown={(e)=>{
+          switch(e.code) {
+            case "Enter":
+            case "Space":
+              e.preventDefault();
+              e.currentTarget.click();
+              break;
+          }
+        }}
         onPointerDown={onPointerDown}
         onPointerOver={onPointerOver}
         onPointerOut={onPointerOut}
+
         style={{
           transform: `translate(${
             CSSVarObject.keyWidth / 2 +


### PR DESCRIPTION
## What's changes?
- Implement keyboard navigation for some MenuContainer Items
- Add accessibility attributes(WAI-ARIA) for MenuContainer Items and MenuContainer
- Add role='link' and aria-current="page" for main tablist(Configure, Key tester, etc)
- Add a button role, tabindex, aria-pressed state, and also add aria-label per each key in Configure tab that keyboard loaded(two-string: 2d keyboard screen)
- Add a switch role for checkbox on the settings screen
- Add attribute, 'htmlFor" to some unassigned label elements for input tag.

## Suggestion

I want to make it accessible for various people likes visually impaired. 

Around me, there are a lot of blind friends who like to using and collecting mechanical keyboards.  But they can't use it because the most components are not accessible from screen readers.

I think this application has the potential to be accessible to various people if some features are implemented.

Unfortunately I'm not good at React and I'm not good at speaking, writing English. 

But, I worked for web accessibility five years ago. If you ask me about various accessibility implementation. I can be helpful to that.

 Can you help me?