### PR TITLE
fix: Add a numeric text field to slider input for fine tune adjustments

### DIFF
--- a/src/components/inputs/accent-range.tsx
+++ b/src/components/inputs/accent-range.tsx
@@ -1,8 +1,11 @@
-import React from 'react';
+import React, {useState} from 'react';
 import styled from 'styled-components';
+import {NumberInput} from 'src/components/panes/configure-panes/submenus/macros/keycode-sequence-components';
 
 const Container = styled.span`
-  display: inline-block;
+  display: flex;
+  gap: 10px;
+  align-items: space-between;
   line-height: initial;
   width: 200px;
 `;
@@ -16,13 +19,21 @@ export const AccentRange: React.FC<
   Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange'> & {
     onChange: (x: number) => void;
   }
-> = (props) => (
-  <Container>
-    <SliderInput
-      {...props}
-      onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-        props.onChange && props.onChange(+e.target.value);
-      }}
-    />
-  </Container>
-);
+> = (props) => {
+  const [value, setValue] = useState<number>(
+    (props.defaultValue as number) || 0,
+  );
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = +e.target.value;
+    setValue(newValue);
+    props.onChange && props.onChange(newValue);
+  };
+
+  return (
+    <Container>
+      <SliderInput {...props} value={value} onChange={handleChange} />
+      <NumberInput {...props} value={value} onChange={handleChange} />
+    </Container>
+  );
+};


### PR DESCRIPTION
I needed functionality to use the slider to control a vast range of possible midi inputs. A fine-tunable slider seemed like the right approached