### PR TITLE
Fix keycode hover in light mode

### DIFF
--- a/src/components/panes/configure-panes/keycode.tsx
+++ b/src/components/panes/configure-panes/keycode.tsx
@@ -102,7 +102,8 @@ const KeycodeContainer = styled.div`
 const KeycodeDesc = styled.div`
   position: fixed;
   bottom: 0;
-  background: #d9d9d97a;
+  background: var(--bg_control);
+  color: var(--color_label-highlighted);
   box-sizing: border-box;
   transition: opacity 0.4s ease-out;
   height: 25px;


### PR DESCRIPTION
Noticed that the hover information for the keycodes was hardcoded to a dark style.
I picked the closest colours that I saw, but there is a difference for the dark style as well, since there was no variable available.

If you want, I can create a separate variable to maintain the exact same colour in dark mode.

![before_after](https://github.com/user-attachments/assets/39997ff6-26fb-4285-86be-9fd2e52cd9eb)
