### PR TITLE
Add support for Mission Control and Launchpad keycodes

### DIFF
--- a/src/utils/key-to-byte/default.ts
+++ b/src/utils/key-to-byte/default.ts
@@ -214,6 +214,8 @@ export default {
   KC_MRWD: 0x00bc,
   KC_BRIU: 0x00bd,
   KC_BRID: 0x00be,
+  KC_MCTL: 0x00c1,
+  KC_LPAD: 0x00c2,
   KC_LCTL: 0x00e0,
   KC_LSFT: 0x00e1,
   KC_LALT: 0x00e2,

--- a/src/utils/key-to-byte/v10.ts
+++ b/src/utils/key-to-byte/v10.ts
@@ -214,6 +214,8 @@ export default {
   KC_MRWD: 0x00bc,
   KC_BRIU: 0x00bd,
   KC_BRID: 0x00be,
+  KC_MCTL: 0x00c1,
+  KC_LPAD: 0x00c2,
   KC_LCTL: 0x00e0,
   KC_LSFT: 0x00e1,
   KC_LALT: 0x00e2,

--- a/src/utils/key-to-byte/v11.ts
+++ b/src/utils/key-to-byte/v11.ts
@@ -214,6 +214,8 @@ export default {
   KC_MRWD: 0x00bc,
   KC_BRIU: 0x00bd,
   KC_BRID: 0x00be,
+  KC_MCTL: 0x00c1,
+  KC_LPAD: 0x00c2,
   KC_MS_UP: 0x00cd,
   KC_MS_DOWN: 0x00ce,
   KC_MS_LEFT: 0x00cf,

--- a/src/utils/key-to-byte/v12.ts
+++ b/src/utils/key-to-byte/v12.ts
@@ -214,6 +214,8 @@ export default {
   KC_MRWD: 0x00bc,
   KC_BRIU: 0x00bd,
   KC_BRID: 0x00be,
+  KC_MCTL: 0x00c1,
+  KC_LPAD: 0x00c2,
   KC_MS_UP: 0x00cd,
   KC_MS_DOWN: 0x00ce,
   KC_MS_LEFT: 0x00cf,

--- a/src/utils/key.ts
+++ b/src/utils/key.ts
@@ -877,6 +877,18 @@ export function getKeycodes(numMacros = 16): IKeycodeMenu[] {
           shortName: 'Scr -',
           title: 'Screen Brightness Down',
         },
+        {
+          name: 'Mission Control',
+          code: 'KC_MCTL',
+          shortName: 'Mctl',
+          title: 'Open Mission Control (macOS)',
+        },
+        {
+          name: 'Launchpad',
+          code: 'KC_LPAD',
+          shortName: 'Lpad',
+          title: 'Open Launchpad (macOS)',
+        },
         {name: 'F13', code: 'KC_F13'},
         {name: 'F14', code: 'KC_F14'},
         {name: 'F15', code: 'KC_F15'},


### PR DESCRIPTION
Hi,

Recently got an Apple-compatible keyset and I realised via didn't offer support for two macOS specific keycodes: `KC_MCTL` and `KC_LPAD` (respectively on `F3` and `F4` on Apple keyboards and laptops), so I made them available to the Configurator.

So far it Works On My Machine™, but I'm new to this so maybe some other files should be modified as well? You tell me and I'll gladly do it.

This commit only adds support in the "Configure" section, so they still won't be recognized by the "Macros" section. To do so would require amending the auto-complete-able keycodes, but I'm not sure there's any incentive to do so given what these two keys do.