### PR TITLE
fix Key Code validation when processing macro strings

### DIFF
--- a/src/utils/autocomplete-keycodes.ts
+++ b/src/utils/autocomplete-keycodes.ts
@@ -203,6 +203,6 @@ export const getAutocompleteKeycodes = () =>
       !!autocompleteKeycodes[keycode.code as keyof typeof autocompleteKeycodes],
   );
 export function isAutocompleteKeycode(keycode: string): boolean {
-  const key = keycode.toUpperCase();
+  const key = keycode.toUpperCase().replace(/^[+-]/, "");
   return !!autocompleteKeycodes[key as keyof typeof autocompleteKeycodes];
 }


### PR DESCRIPTION
This PR addresses https://github.com/the-via/releases/issues/273, which is caused by broken input validation code that doesn't consider `+`/`-` characters (for example, in the string `{+KC_LGUI}a{-KC_LGUI}`) when validating macros.

The change updates the `isAutocompleteKeycode` function to strip leading "+" or "-" characters from the `keycode` before checking it against `autocompleteKeycodes`.