### PR TITLE
Fixing an issue where valid HID responses are discarded

### DIFF
--- a/src/shims/node-hid.ts
+++ b/src/shims/node-hid.ts
@@ -3,6 +3,8 @@ import type {
   ConnectedDevice,
   WebVIADevice,
 } from '../types/types';
+
+var lastWriteTimestamp = Date.now();
 // This is a bit cray
 const globalBuffer: {
   [path: string]: {currTime: number; message: Uint8Array}[];
@@ -143,7 +145,7 @@ const ExtendedHID = {
     }
 
     read(fn: (err?: Error, data?: ArrayBuffer) => void) {
-      this.fastForwardGlobalBuffer(Date.now());
+      this.fastForwardGlobalBuffer(lastWriteTimestamp);
       if (globalBuffer[this.path].length > 0) {
         // this should be a noop normally
         fn(undefined, globalBuffer[this.path].shift()?.message as any);
@@ -172,6 +174,7 @@ const ExtendedHID = {
     async write(arr: number[]) {
       await this.openPromise;
       const data = new Uint8Array(arr.slice(1));
+      lastWriteTimestamp = Date.now();
       await this._hidDevice?._device.sendReport(0, data);
     }
   },


### PR DESCRIPTION
I have observed that occasionally VIA will not complete the Authorize Device process. Also, for a larger keyboards especially, the Test Matrix feature will consistently lock up and stop responding after a few seconds (whereas disabling "Test Matrix" continues to work just fine). After a bit of in-browser debugging, I learned that the call to `fastForwardGlobalBuffer` discards HID responses received prior to whenever `read` was called.

It turns out that due to the use of `async`/`await`, there can be some delay between the `write` function call and the `read` function call. What was happening was that the device had already responded quickly between the time when `write` was called and the time when `read` was called. Whenever the device responds before `read` is called, that response is then erroneously discarded by the fast forward function. VIA is then stuck waiting for a response that will never arrive (because it already did arrive, and was discarded), causing Test Matrix to stop working, and/or causing the authorization process to halt.

This PR makes it so that `fastForwardGlobalBuffer` only discards messages prior to the previous call to `write` instead of discarding messages prior to when `read` is called.

Note that these changes were tested by editing the code through browser developer tools by enabling overrides and thus running it in-browser. The changes in this PR match what I did in-browser and it looks correct to me, but I haven't actually run/tested the committed changes as-is simply because I haven't set up an environment to run/host VIA independently. That being said, I can confirm these when I made these same changes in-browser, they worked and actually fixed the issues I was experiencing.

Edit: It should also be noted that the problems I mentioned would only show up when the CPU load was higher (i.e. lots of tabs open in the browser, or on older computers).