### PR TITLE
Fix valid checking for keycodes

### DIFF
--- a/src/components/inputs/custom-keycode-modal.tsx
+++ b/src/components/inputs/custom-keycode-modal.tsx
@@ -49,8 +49,7 @@ type KeycodeModalProps = {
 
 function isHex(input: string): boolean {
   const lowercased = input.toLowerCase();
-  const parsed = parseInt(lowercased, 16);
-  return `0x${parsed.toString(16).toLowerCase()}` === lowercased;
+  return /^0x[0-9a-f]{1,4}$/.test(lowercased);
 }
 
 // This is hella basic 💁‍♀️💁‍♂️

--- a/src/components/panes/configure-panes/save-load.tsx
+++ b/src/components/panes/configure-panes/save-load.tsx
@@ -196,11 +196,22 @@ export const Pane: FC = () => {
         dispatch(saveMacros(selectedDevice, saveFile.macros));
       }
 
+      let parseErrors: string[] = [];
       const keymap: number[][] = saveFile.layers.map((layer) =>
-        layer.map((key) =>
-          getByteForCode(`${deprecatedKeycodes[key] ?? key}`, basicKeyToByte),
-        ),
+        layer.map((key) => {
+          try {
+            return getByteForCode(`${deprecatedKeycodes[key] ?? key}`, basicKeyToByte);
+          } catch (error) {
+            console.error(error);
+            parseErrors.push(`"${key}"`);
+            return 0;
+          }
+        }),
       );
+
+      if (parseErrors.length > 0) {
+        setErrorMessage(`Unsupported keycodes: ${parseErrors.join(', ')}`);
+      }
 
       // John you drongo, don't trust the compiler, dispatches are totes awaitable for async thunks
       await dispatch(saveRawKeymapToDevice(keymap, selectedDevice));

--- a/src/utils/key.ts
+++ b/src/utils/key.ts
@@ -76,7 +76,7 @@ export function getByteForCode(
     return byte;
   } else if (isLayerCode(code)) {
     return getByteForLayerCode(code, basicKeyToByte);
-  } else if (advancedStringToKeycode(code, basicKeyToByte) !== null) {
+  } else if (advancedStringToKeycode(code, basicKeyToByte) !== 0) {
     return advancedStringToKeycode(code, basicKeyToByte);
   }
   throw `Could not find byte for ${code}`;
@@ -263,7 +263,7 @@ export function keycodeInMaster(
   return (
     keycode in basicKeyToByte ||
     isLayerCode(keycode) ||
-    advancedStringToKeycode(keycode, basicKeyToByte) !== null
+    advancedStringToKeycode(keycode, basicKeyToByte) !== 0
   );
 }
 


### PR DESCRIPTION
This PR fixed valid checking for keycode in some situations

1. When using hex code in custom key `any`, now only accept hex formed string in range of `0x0000` and `0xffff`, including leading zero value and non leading zero value 
   - Before changes
   <img width="510" alt="28426ca97f222a3781dc1f2cf1da4fbf" src="https://github.com/user-attachments/assets/d1170865-ef83-426b-9927-1a94adad9d0b" /><img width="504" alt="4c2844a920d0a5d862c6719610d8ef6f" src="https://github.com/user-attachments/assets/f72642b8-dba7-4843-b9ec-445f62ff832e" /><img width="497" alt="f2e759262b92872b9a1b0498303cd37d" src="https://github.com/user-attachments/assets/e5513c39-bc50-4c60-8640-b90bc4efe65a" />
    - After changes
    <img width="501" alt="image" src="https://github.com/user-attachments/assets/3e32f82f-caba-4e84-a941-26c56d2848f7" /><img width="496" alt="image" src="https://github.com/user-attachments/assets/8b3461f7-824d-41bd-b56a-cb09df7c2dc7" /><img width="500" alt="image" src="https://github.com/user-attachments/assets/0cd14afc-8baa-4e63-a4eb-2b8cbac561f6" /><img width="498" alt="image" src="https://github.com/user-attachments/assets/d04aad50-a713-41e9-95a1-4da26a7689d1" />

2. Dim the unsupported keys in select area and block click actions, it is a previously built function and disabled due to the bug
   <img width="299" alt="image" src="https://github.com/user-attachments/assets/8282ddec-353a-44ef-8ad7-ef0fc007b08d" />

3. When selecting an unsupported keycode (if possible), block the applying action.
   Before the changes, it will apply with keycode `0` (aka. `KC_NO`)

4. When applying a saved layout which includes unsupported keycodes, replace them with `KC_NO`, port error message to console and list them on web page
<img width="998" alt="image" src="https://github.com/user-attachments/assets/9ca48141-0850-4862-a1f0-a5b51ee67327" />
<img width="409" alt="image" src="https://github.com/user-attachments/assets/d1aaecc9-472b-4699-b90c-18aff46327c3" />

    There is no message output before changes.