### PR TITLE
Fix select component use defaultValue never trigger scroll into view

### DIFF
--- a/src/components/panes/configure-panes/custom/custom-control.tsx
+++ b/src/components/panes/configure-panes/custom/custom-control.tsx
@@ -149,7 +149,7 @@ const VIACustomControl = (props: VIACustomControlProps) => {
             option && props.updateValue(name, ...command, +option.value)
           }
           options={selectOptions}
-          defaultValue={selectOptions.find((p: any) => value[0] === p.value)}
+          value={selectOptions.find((p: any) => value[0] === p.value)}
         />
       );
     }

--- a/src/components/panes/configure-panes/layouts.tsx
+++ b/src/components/panes/configure-panes/layouts.tsx
@@ -32,7 +32,7 @@ const LayoutControl: React.FC<{
         <Detail>
           <AccentSelect
             /*width={150}*/
-            defaultValue={options[selectedOption]}
+            value={options[selectedOption]}
             options={options}
             onChange={(option: any) => {
               if (option) {

--- a/src/components/panes/configure-panes/submenus/lighting/lighting-control.tsx
+++ b/src/components/panes/configure-panes/submenus/lighting/lighting-control.tsx
@@ -101,7 +101,7 @@ export const LightingControl = (props: AdvancedControlProps) => {
                 }
               }}
               options={options as any}
-              defaultValue={(options as any).find(
+              value={(options as any).find(
                 (p: any) => valArr[0] === p.value,
               )}
             />

--- a/src/components/panes/debug.tsx
+++ b/src/components/panes/debug.tsx
@@ -156,7 +156,7 @@ const TestControls = () => {
         <Label>{+selectionVal}</Label>
         <Detail>
           <AccentSelect
-            defaultValue={selectOptions[selectionVal]}
+            value={selectOptions[selectionVal]}
             options={selectOptions}
             onChange={(option: any) => {
               option && setSelectionVal(+option.value);

--- a/src/components/panes/settings.tsx
+++ b/src/components/panes/settings.tsx
@@ -133,7 +133,8 @@ export const Settings = () => {
               <Label>Keycap Theme</Label>
               <Detail>
                 <AccentSelect
-                  defaultValue={themeDefaultValue}
+                defaultValue={themeDefaultValue}
+                  value={themeName}
                   options={themeSelectOptions}
                   onChange={(option: any) => {
                     option && dispatch(updateThemeName(option.value));

--- a/src/components/panes/test.tsx
+++ b/src/components/panes/test.tsx
@@ -213,7 +213,7 @@ export const Test: FC = () => {
               <Detail>
                 <AccentSelect
                   isSearchable={false}
-                  defaultValue={waveformDefaultValue}
+                  value={waveformDefaultValue}
                   options={waveformOptions}
                   onChange={(option: any) => {
                     option &&


### PR DESCRIPTION
Use `value` instead of `defaultValue` to ensure that `currentValue` can be scrolled into view.
Compare:
before use defaultValue:
![before](https://github.com/user-attachments/assets/9b99cb92-668b-4ad2-b153-e2a404049387)

after use value:
![after](https://github.com/user-attachments/assets/0dc77773-2f4f-40bc-bf76-fbbf86bccdb3)
