### PR TITLE
Slider Modes Selector

### DIFF
--- a/src/components/inputs/accent-range.tsx
+++ b/src/components/inputs/accent-range.tsx
@@ -1,19 +1,42 @@
 import React, {useState, useEffect} from 'react';
 import styled from 'styled-components';
 import {useAppSelector} from 'src/store/hooks';
-import {getShowSliderValues} from 'src/store/settingsSlice';
+import {getShowSliderValuesMode} from 'src/store/settingsSlice';
+import {NumberInput} from 'src/components/panes/configure-panes/submenus/macros/keycode-sequence-components';
 
-const Container = styled.span<{$showValue?: boolean}>`
+const Container = styled.span<{$mode?: number}>`
   display: inline-flex;
-  align-items: center;
+  align-items: center; /* Changed from space-between to center */
   line-height: initial;
-  gap: ${(props) => (props.$showValue ? '10px' : '0')};
-  width: ${(props) => (props.$showValue ? 'auto' : '200px')};
+  gap: ${(props) => (props.$mode === 1 ? '10px' : '8px')};
+  width: ${(props) => {
+    switch (props.$mode) {
+      case 0:
+        return '200px'; // Slider only
+      case 1:
+        return 'auto'; // Slider + value display
+      case 2:
+        return '280px'; // Slider + input field
+      default:
+        return '200px';
+    }
+  }};
 `;
 
 const SliderInput = styled.input.attrs({type: 'range'})<any>`
   accent-color: var(--color_accent);
-  width: ${(props) => (props.$showValue ? '200px' : '100%')};
+  width: ${(props) => {
+    switch (props.$mode) {
+      case 0:
+        return '100%'; // Full width when alone
+      case 1:
+        return '200px'; // Fixed width with value display
+      case 2:
+        return '180px'; // Smaller with input field
+      default:
+        return '100%';
+    }
+  }};
   flex: none;
 `;
 
@@ -25,13 +48,28 @@ const ValueDisplay = styled.span`
   min-width: 40px;
 `;
 
+const StyledNumberInput = styled(NumberInput)`
+  width: 80px;
+  flex: none;
+`;
+
 export const AccentRange: React.FC<
   Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange'> & {
     onChange: (x: number) => void;
   }
 > = (props) => {
-  // Get the dynamic value from Redux store
-  const showValue = useAppSelector(getShowSliderValues);
+  // Get the display mode from Redux store (0, 1, or 2)
+  const displayMode = useAppSelector(getShowSliderValuesMode);
+
+  // Convert string mode to numeric mode
+  const numericMode =
+    displayMode === 'Slider Only'
+      ? 0
+      : displayMode === 'Slider & Show Value'
+      ? 1
+      : displayMode === 'Slider & Input Field'
+      ? 2
+      : 0;
 
   const [currentValue, setCurrentValue] = useState<number>(
     Number(props.defaultValue || props.value || props.min || 0),
@@ -44,18 +82,43 @@ export const AccentRange: React.FC<
     setCurrentValue(newValue);
   }, [props.defaultValue, props.value, props.min]);
 
+  const handleChange = (newValue: number) => {
+    setCurrentValue(newValue);
+    props.onChange && props.onChange(newValue);
+  };
+
+  const handleSliderChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = +e.target.value;
+    handleChange(newValue);
+  };
+
+  const handleNumberInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = +e.target.value;
+    handleChange(newValue);
+  };
+
   return (
-    <Container $showValue={showValue}>
-      {showValue && <ValueDisplay>{currentValue}</ValueDisplay>}
+    <Container $mode={numericMode}>
+      {/* Mode 1: Show value display */}
+      {numericMode === 1 && <ValueDisplay>{currentValue}</ValueDisplay>}
+
+      {/* Always show slider */}
       <SliderInput
         {...props}
-        $showValue={showValue}
-        onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-          const newValue = +e.target.value;
-          setCurrentValue(newValue);
-          props.onChange && props.onChange(newValue);
-        }}
+        $mode={numericMode} /* Pass numeric mode here too */
+        value={currentValue}
+        onChange={handleSliderChange}
       />
+
+      {/* Mode 2: Show input field */}
+      {numericMode === 2 && (
+        <StyledNumberInput
+          {...props}
+          type="number"
+          value={currentValue}
+          onChange={handleNumberInputChange}
+        />
+      )}
     </Container>
   );
 };

--- a/src/components/panes/settings.tsx
+++ b/src/components/panes/settings.tsx
@@ -17,10 +17,10 @@ import {useAppSelector} from 'src/store/hooks';
 import {
   getShowDesignTab,
   getDisableFastRemap,
-  getShowSliderValues,
+  getShowSliderValuesMode,
   toggleCreatorMode,
   toggleFastRemap,
-  toggleShowSliderValues,
+  updateShowSliderValuesMode,
   getThemeMode,
   toggleThemeMode,
   getThemeName,
@@ -59,7 +59,7 @@ export const Settings = () => {
   const dispatch = useDispatch();
   const showDesignTab = useAppSelector(getShowDesignTab);
   const disableFastRemap = useAppSelector(getDisableFastRemap);
-  const showSliderValues = useAppSelector(getShowSliderValues);
+  const ShowSliderValuesMode = useAppSelector(getShowSliderValuesMode);
   const themeMode = useAppSelector(getThemeMode);
   const themeName = useAppSelector(getThemeName);
   const renderMode = useAppSelector(getRenderMode);
@@ -73,6 +73,26 @@ export const Settings = () => {
   }));
   const themeDefaultValue = themeSelectOptions.find(
     (opt) => opt.value === themeName,
+  );
+
+  const ShowSliderModeOptions = webGLIsAvailable
+    ? [
+        {
+          label: 'Slider Only',
+          value: 'Slider Only',
+        },
+        {
+          label: 'Slider & Show Value',
+          value: 'Slider & Show Value',
+        },
+        {
+          label: 'Slider & Input Field',
+          value: 'Slider & Input Field',
+        },
+      ]
+    : [{label: 'Slider Only', value: 'Slider Only'}];
+  const showSliderModeDefaultValue = ShowSliderModeOptions.find(
+    (opt) => opt.value === ShowSliderValuesMode,
   );
 
   const renderModeOptions = webGLIsAvailable
@@ -124,11 +144,14 @@ export const Settings = () => {
               </Detail>
             </ControlRow>
             <ControlRow>
-              <Label>Show Slider Values</Label>
+              <Label>Slider Modes</Label>
               <Detail>
-                <AccentSlider
-                  onChange={() => dispatch(toggleShowSliderValues())}
-                  isChecked={showSliderValues}
+                <AccentSelect
+                  defaultValue={showSliderModeDefaultValue}
+                  options={ShowSliderModeOptions}
+                  onChange={(option: any) => {
+                    option && dispatch(updateShowSliderValuesMode(option.value));
+                  }}
                 />
               </Detail>
             </ControlRow>

--- a/src/store/settingsSlice.ts
+++ b/src/store/settingsSlice.ts
@@ -42,8 +42,14 @@ const settingsSlice = createSlice({
     toggleFastRemap: (state) => {
       toggleBool(state, 'disableFastRemap');
     },
-    toggleShowSliderValues: (state) => {
-      toggleBool(state, 'showSliderValues');
+    updateShowSliderValuesMode: (
+      state,
+      action: PayloadAction<
+        'Slider Only' | 'Slider & Show Value' | 'Slider & Input Field'
+      >,
+    ) => {
+      state.ShowSliderValuesMode = action.payload;
+      setSettings(state);
     },
     toggleCreatorMode: (state) => {
       toggleBool(state, 'showDesignTab');
@@ -106,7 +112,7 @@ const settingsSlice = createSlice({
 
 export const {
   toggleFastRemap,
-  toggleShowSliderValues,
+  updateShowSliderValuesMode,
   toggleCreatorMode,
   setTestMatrixEnabled,
   setTestKeyboardSoundsSettings,
@@ -127,8 +133,8 @@ export const getAllowGlobalHotKeys = (state: RootState) =>
   state.settings.allowGlobalHotKeys;
 export const getDisableFastRemap = (state: RootState) =>
   state.settings.disableFastRemap;
-export const getShowSliderValues = (state: RootState) =>
-  state.settings.showSliderValues;
+export const getShowSliderValuesMode = (state: RootState) =>
+  webGLIsAvailable ? state.settings.ShowSliderValuesMode : 'Slider Only';
 export const getShowDesignTab = (state: RootState) =>
   state.settings.showDesignTab;
 export const getRestartRequired = (state: RootState) =>

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -84,7 +84,7 @@ export type TestKeyboardSoundsSettings = {
 export type Settings = {
   showDesignTab: boolean;
   disableFastRemap: boolean;
-  showSliderValues: boolean;
+  ShowSliderValuesMode: 'Slider Only' | 'Slider & Show Value' | 'Slider & Input Field';
   renderMode: '3D' | '2D';
   themeMode: 'light' | 'dark';
   themeName: string;

--- a/src/utils/device-store.ts
+++ b/src/utils/device-store.ts
@@ -30,7 +30,7 @@ const defaultStoreData = {
   settings: {
     showDesignTab: false,
     disableFastRemap: false,
-    showSliderValues: false,
+    ShowSliderValuesMode: 'Slider Only' as const,
     renderMode: '2D' as const,
     themeMode: 'dark' as const,
     designDefinitionVersion: 'v3' as const,
@@ -162,6 +162,10 @@ export const getThemeFromStore = (): ThemeDefinition =>
 
 export const getThemeModeFromStore = (): 'dark' | 'light' => {
   return deviceStore.get('settings')?.themeMode;
+};
+
+export const getShowSliderValuesModeFromStore = (): 'Slider & Show Value' | 'Slider & Input Field' | 'Slider Only' => {
+  return deviceStore.get('settings')?.ShowSliderValuesMode;
 };
 
 export const getRenderModeFromStore = (): '3D' | '2D' => {


### PR DESCRIPTION
Adds a slider mode selector:
<img width="981" height="219" alt="image" src="https://github.com/user-attachments/assets/886860bd-f928-4ec6-b23f-c6fee46da03f" />

Slider only:
<img width="296" height="170" alt="Screenshot 2026-01-12 at 11 22 48 PM" src="https://github.com/user-attachments/assets/1cfb23f9-11e3-4ab7-9620-934b575653ef" />

Slider & Show Value:
<img width="313" height="172" alt="Screenshot 2026-01-12 at 11 23 07 PM" src="https://github.com/user-attachments/assets/a973e325-1175-4fa2-8669-100455654c03" />

Slider & Input Field:
<img width="319" height="175" alt="Screenshot 2026-01-12 at 11 23 21 PM" src="https://github.com/user-attachments/assets/1d0b8568-c778-48e5-8aae-a41f052c08dc" />
