### PR TITLE
Remove extraneous value property on keycap theme dropdown

### DIFF
--- a/src/components/panes/settings.tsx
+++ b/src/components/panes/settings.tsx
@@ -170,8 +170,7 @@ export const Settings = () => {
               <Label>{t('Keycap Theme')}</Label>
               <Detail>
                 <AccentSelect
-                defaultValue={themeDefaultValue}
-                  value={themeName}
+                  defaultValue={themeDefaultValue}
                   options={themeSelectOptions}
                   onChange={(option: any) => {
                     option && dispatch(updateThemeName(option.value));


### PR DESCRIPTION
Keycap theme selection always showing `Select...`. 
Functions fine otherwise- the colour scheme is applies, but name immediately resets to `Select...`

The cause appears to be the 'value' property of this dropdown being explicitly set
Removed this to resolve.

<img width="676" height="237" alt="image" src="https://github.com/user-attachments/assets/02b77fd9-2562-4890-a2c0-356e8b507e0c" />
