### PR TITLE
fix: re-open HID device before write if connection was lost

### DIFF
--- a/src/shims/node-hid.ts
+++ b/src/shims/node-hid.ts
@@ -171,6 +171,9 @@ const ExtendedHID = {
 
     async write(arr: number[]) {
       await this.openPromise;
+      if (this._hidDevice && !this._hidDevice._device.opened) {
+        await this.open();
+      }
       const data = new Uint8Array(arr.slice(1));
       await this._hidDevice?._device.sendReport(0, data);
     }


### PR DESCRIPTION
## Problem
On Linux + Chrome, the WebHID device handle can become stale after USB suspend/resume or transient disconnects. The write() method only awaited the initial openPromise, which was already resolved from the first successful open. Subsequent sendReport() calls on the closed handle threw InvalidStateError: The device must be opened first.

## Fix
Check _device.opened before each write and re-open if needed.

## Testing
- Verified TypeScript compiles with no errors
- Tested with BUBBLE 75 (VID: 0x4242, PID: 0x5A4C) on Linux + Chrome