### PR TITLE
fix: use instancePath instead of dataPath

### DIFF
--- a/src/components/panes/design.tsx
+++ b/src/components/panes/design.tsx
@@ -173,7 +173,7 @@ function importDefinitions(
                   []
             ).map(
               (e) =>
-                `${fileName} ${e.dataPath ? e.dataPath + ': ' : 'Object: '}${
+                `${fileName} ${e.instancePath ? e.instancePath + ': ' : 'Object: '}${
                   e.message
                 }`,
             );


### PR DESCRIPTION
https://github.com/the-via/reader requires ajv v8, and since that change was introduced in 1.13.x the build for VIA is also required to use ajv v8.

And according to https://ajv.js.org/v6-to-v8-migration.html:
> dataPath property replaced with instancePath

This fixes the build that has been failing since last month.
https://github.com/the-via/app/actions/runs/24546561765/job/71763342022