### PR TITLE
Fix key tester audio clipping with simultaneous key sounds

### DIFF
--- a/src/components/void/test-keyboard-sounds.ts
+++ b/src/components/void/test-keyboard-sounds.ts
@@ -58,6 +58,7 @@ const calculateMidiNote = (
 
 const turnOffAllTheNotes = () => {
   Object.values(notes).forEach((note) => note?.noteOff());
+  notes = {};
 };
 
 export const TestKeyboardSounds: React.FC<{
@@ -93,10 +94,12 @@ export const TestKeyboardSounds: React.FC<{
                   row,
                   col,
                 );
+                notes[index]?.noteOff(true);
                 notes[index] = new Note(midiNote, waveform);
                 notes[index].noteOn();
               } else if (state == TestKeyState.KeyUp) {
                 notes[index]?.noteOff();
+                delete notes[index];
               }
             }
             return [...p2, n2];

--- a/src/utils/note.ts
+++ b/src/utils/note.ts
@@ -18,9 +18,19 @@ function getAudioContext(): AudioContext {
 function getGlobalAmp(): GainNode {
   if (globalAmp === undefined) {
     const audioContext = getAudioContext();
+    // Keep the original note gain/volume behavior, but add a compressor at the
+    // output bus to prevent clipping when several key sounds are summed.
+    const compressor = audioContext.createDynamicsCompressor();
+    compressor.threshold.value = -6;
+    compressor.knee.value = 3;
+    compressor.ratio.value = 12;
+    compressor.attack.value = 0.003;
+    compressor.release.value = 0.08;
+
     globalAmp = audioContext.createGain();
     globalAmp.gain.value = globalAmpGain;
-    globalAmp.connect(audioContext.destination);
+    globalAmp.connect(compressor);
+    compressor.connect(audioContext.destination);
   }
   return globalAmp;
 }
@@ -34,13 +44,17 @@ export function setGlobalAmpGain(ampGain: number) {
   }
   // This fixes a crackle sound when changing volume slider quickly
   // while playing a note.
+  const audioContext = getAudioContext();
+  // Cancel pending volume automation so rapid slider changes do not stack
+  // conflicting ramps on the same GainNode.
+  globalAmp.gain.cancelScheduledValues(audioContext.currentTime);
   globalAmp.gain.setValueAtTime(
     globalAmp.gain.value,
-    getAudioContext().currentTime,
+    audioContext.currentTime
   );
   globalAmp.gain.linearRampToValueAtTime(
     globalAmpGain,
-    getAudioContext().currentTime + 0.2,
+    audioContext.currentTime + 0.2,
   );
 }
 
@@ -80,7 +94,7 @@ export class Note {
     );
   }
 
-  noteOff(): void {
+  noteOff(immediate: boolean = false): void {
     // This fixes a click sound if the gain ramp to 0 happens
     // in the middle of sustain, i.e. after the previous
     // gain ramp ends.
@@ -90,8 +104,9 @@ export class Note {
         this.audioContext.currentTime,
       );
     }
+    const releaseTime = immediate ? 0 : ampRelease;
     const stopTime =
-      Math.max(this.audioContext.currentTime, this.ampSustainTime) + ampRelease;
+      Math.max(this.audioContext.currentTime, this.ampSustainTime) + releaseTime;
     this.osc.stop(stopTime);
     this.amp.gain.linearRampToValueAtTime(0, stopTime);
   }


### PR DESCRIPTION
## Summary

Fixes audible distortion in the key tester when several key sounds are played at the same time, while keeping the normal key sound volume behavior.

## Changes

- Add a dynamics compressor to the key sound output bus to reduce clipping when multiple oscillators are summed.
- Keep the existing per-note gain and master volume behavior so simultaneous key sounds do not become noticeably quieter.
- Fix oscillator overlap when rapidly re-pressing the same key by immediately stopping the previous note instead of waiting for the release envelope.

## Cause

Each key sound used a fixed per-note gain, and all notes were summed directly into the global output. With several simultaneous notes, the combined signal could exceed the output range and clip, causing noticeable distortion.
