### PR TITLE
Fix 3D Cubey body theme colors

### DIFF
--- a/src/components/three-fiber/loader-cubey.tsx
+++ b/src/components/three-fiber/loader-cubey.tsx
@@ -16,8 +16,8 @@ export const LoaderCubey: React.FC<{theme: Theme; visible: boolean}> =
 
     const darkAccent = getDarkenedColor(theme.accent.c, 0.8);
     const colorMap = {
-      'upper-body': new Color(theme.mod.c),
-      'lower-body': new Color(theme.mod.t),
+      'upper-body': new Color(theme.mod.t),
+      'lower-body': new Color(theme.mod.c),
       accent: new Color(darkAccent),
       bowtie: new Color(darkAccent),
     };


### PR DESCRIPTION
## Summary

Correct 3D Cubey body colors so the loader follows the selected theme correctly.

## Reference

2D reference:

<img width="720" alt="image" src="https://github.com/user-attachments/assets/7fcb9f97-3284-4be5-85c7-a4956ee4653f" />

Before:

<img width="720" alt="image" src="https://github.com/user-attachments/assets/737e4f82-dcf6-4621-a315-19e6c8ccc2f2" />

After:

<img width="720" alt="image" src="https://github.com/user-attachments/assets/31e63e8c-3c4b-43e1-a57f-f747f47f0b8a" />