### PR TITLE
Fix keycap rendering issues

### DIFF
--- a/src/components/inputs/accent-range.tsx
+++ b/src/components/inputs/accent-range.tsx
@@ -58,6 +58,8 @@ export const AccentRange: React.FC<
     onChange: (x: number) => void;
   }
 > = (props) => {
+  const {defaultValue, ...inputProps} = props;
+
   // Get the display mode from Redux store (0, 1, or 2)
   const displayMode = useAppSelector(getShowSliderValuesMode);
 
@@ -104,7 +106,7 @@ export const AccentRange: React.FC<
 
       {/* Always show slider */}
       <SliderInput
-        {...props}
+        {...inputProps}
         $mode={numericMode} /* Pass numeric mode here too */
         value={currentValue}
         onChange={handleSliderChange}
@@ -113,7 +115,7 @@ export const AccentRange: React.FC<
       {/* Mode 2: Show input field */}
       {numericMode === 2 && (
         <StyledNumberInput
-          {...props}
+          {...inputProps}
           type="number"
           value={currentValue}
           onChange={handleNumberInputChange}

--- a/src/components/n-links/keyboard/configure.tsx
+++ b/src/components/n-links/keyboard/configure.tsx
@@ -18,6 +18,8 @@ import {KeyboardCanvas as StringKeyboardCanvas} from '../../two-string/keyboard-
 export const getKeyboardCanvas = (dimension: '2D' | '3D') =>
   dimension === '2D' ? StringKeyboardCanvas : FiberKeyboardCanvas;
 
+const EMPTY_KEYMAP: number[] = [];
+
 export const ConfigureKeyboard = (props: {
   selectable?: boolean;
   dimensions?: DOMRect;
@@ -25,7 +27,7 @@ export const ConfigureKeyboard = (props: {
 }) => {
   const {selectable, dimensions} = props;
   const matrixKeycodes = useAppSelector(
-    (state) => getSelectedKeymap(state) || [],
+    (state) => getSelectedKeymap(state) || EMPTY_KEYMAP,
   );
   const keys: (VIAKey & {ei?: number})[] = useAppSelector(
     getSelectedKeyDefinitions,

--- a/src/components/n-links/keyboard/test.tsx
+++ b/src/components/n-links/keyboard/test.tsx
@@ -28,6 +28,7 @@ import fullKeyboardDefinition from '../../../utils/test-keyboard-definition.json
 import {TestContext} from '../../panes/test';
 import {getKeyboardCanvas} from './configure';
 const EMPTY_ARR = [] as any[];
+const EMPTY_KEYMAP: number[] = [];
 export const Test = (props: {dimensions?: DOMRect; nDimension: NDimension}) => {
   const dispatch = useAppDispatch();
   const [path] = useLocation();
@@ -41,7 +42,7 @@ export const Test = (props: {dimensions?: DOMRect; nDimension: NDimension}) => {
     getTestKeyboardSoundsSettings,
   );
   const selectedMatrixKeycodes = useAppSelector(
-    (state) => getSelectedKeymap(state) || [],
+    (state) => getSelectedKeymap(state) || EMPTY_KEYMAP,
   );
 
   const [globalPressedKeys, setGlobalPressedKeys] = useGlobalKeys(

--- a/src/components/panes/configure-panes/encoder.tsx
+++ b/src/components/panes/configure-panes/encoder.tsx
@@ -32,6 +32,8 @@ const Container = styled.div`
   padding: 0 12px;
 `;
 
+const EMPTY_KEYMAP: number[] = [];
+
 export const Pane: FC = () => {
   const {t} = useTranslation();
   const [cwValue, setCWValue] = useState<number>();
@@ -42,7 +44,7 @@ export const Pane: FC = () => {
     getSelectedKeyDefinitions,
   );
   const matrixKeycodes = useAppSelector(
-    (state) => getSelectedKeymap(state) || [],
+    (state) => getSelectedKeymap(state) || EMPTY_KEYMAP,
   );
   const layer = useAppSelector(getSelectedLayerIndex);
   const selectedDevice = useAppSelector(getSelectedConnectedDevice);

--- a/src/components/three-fiber/unit-key/keycap.tsx
+++ b/src/components/three-fiber/unit-key/keycap.tsx
@@ -347,7 +347,11 @@ export const Keycap: React.FC<ThreeFiberKeycapProps> = React.memo((props) => {
         );
         setOverflowsTexture(!!doesOverflow);
       }
-      textureRef.current!.needsUpdate = true;
+      if (!textureRef.current) {
+        textureRef.current = new THREE.CanvasTexture(canvasRef.current);
+      } else {
+        textureRef.current.needsUpdate = true;
+      }
     }
   }, [
     canvasRef.current,
@@ -358,6 +362,7 @@ export const Keycap: React.FC<ThreeFiberKeycapProps> = React.memo((props) => {
     color && color.t,
     color && color.c,
     shouldRotate,
+    textureOffsetX,
   ]);
   useEffect(redraw, [label && label.key, color && color.c, color && color.t]);
 
@@ -377,8 +382,8 @@ export const Keycap: React.FC<ThreeFiberKeycapProps> = React.memo((props) => {
         ? KeycapState.Pressed
         : KeycapState.Unpressed
       : hovered || selected
-      ? KeycapState.Unpressed
-      : KeycapState.Pressed;
+      ? KeycapState.Pressed
+      : KeycapState.Unpressed;
   const [keycapZ, rotationZ] =
     pressedState === KeycapState.Pressed
       ? [zDown, rotation[2]]

--- a/src/components/two-string/key-group.tsx
+++ b/src/components/two-string/key-group.tsx
@@ -73,18 +73,20 @@ export const KeyGroup: React.FC<KeyGroupProps<React.MouseEvent>> = (props) => {
   const {width, height} = calculateKeyboardFrameDimensions(keys);
   const elems = useMemo(() => {
     return props.keys.map((k, i) => {
+      const {key, ...keycapProps} = getKeycapSharedProps(
+        k,
+        i,
+        props,
+        keysKeys,
+        selectedKeyIndex,
+        labels,
+        skipFontCheck,
+      );
       return k.d ? null : (
         <Keycap
+          key={key}
           {...getComboKeyProps(k)}
-          {...getKeycapSharedProps(
-            k,
-            i,
-            props,
-            keysKeys,
-            selectedKeyIndex,
-            labels,
-            skipFontCheck,
-          )}
+          {...keycapProps}
         />
       );
     });

--- a/src/components/two-string/unit-key/keycap.tsx
+++ b/src/components/two-string/unit-key/keycap.tsx
@@ -49,22 +49,12 @@ const paintDebugLines = (canvas: HTMLCanvasElement) => {
 };
 
 const paintKeycapLabel = (
-  canvas: HTMLCanvasElement,
+  context: CanvasRenderingContext2D,
+  canvasWidth: number,
+  canvasHeight: number,
   legendColor: string,
   label: any,
 ) => {
-  const context = canvas.getContext('2d');
-  if (context == null) {
-    return;
-  }
-  const dpi = devicePixelRatio;
-  const [canvasWidth, canvasHeight] = [canvas.width, canvas.height];
-  canvas.width = canvasWidth * dpi;
-  canvas.height = canvasHeight * dpi;
-  canvas.style.width = `${canvasWidth}px`;
-  canvas.style.height = `${canvasHeight}px`;
-
-  context.scale(dpi, dpi);
   const fontFamily =
     'Fira Sans, Arial Rounded MT, Arial Rounded MT Bold, Arial';
   // Margins from face edge to where text is drawn
@@ -76,9 +66,9 @@ const paintKeycapLabel = (
   // Define a clipping path for the top face, so text is not drawn on the side.
   context.beginPath();
   context.moveTo(0, 0);
-  context.lineTo(canvas.width, 0);
-  context.lineTo(canvas.width, canvas.height);
-  context.lineTo(0, canvas.height);
+  context.lineTo(canvasWidth, 0);
+  context.lineTo(canvasWidth, canvasHeight);
+  context.lineTo(0, canvasHeight);
   context.lineTo(0, 0);
   context.clip();
 
@@ -134,21 +124,25 @@ const paintKeycap = (
   legendColor: string,
   label: any,
 ) => {
-  const [canvasWidth, canvasHeight] = [
-    CSSVarObject.keyWidth,
-    CSSVarObject.keyHeight,
-  ];
-  canvas.width =
-    canvasWidth * textureWidth -
+  const logicalWidth =
+    CSSVarObject.keyWidth * textureWidth -
     CSSVarObject.faceXPadding.reduce((x, y) => x + y, 0);
-  canvas.height =
-    canvasHeight * textureHeight -
+  const logicalHeight =
+    CSSVarObject.keyHeight * textureHeight -
     CSSVarObject.faceYPadding.reduce((x, y) => x + y, 0);
+  const dpi = window.devicePixelRatio || 1;
+
+  canvas.width = Math.ceil(logicalWidth * dpi);
+  canvas.height = Math.ceil(logicalHeight * dpi);
+  canvas.style.width = `${logicalWidth}px`;
+  canvas.style.height = `${logicalHeight}px`;
 
   const context = canvas.getContext('2d');
   if (context == null) {
     return;
   }
+  context.setTransform(dpi, 0, 0, dpi, 0, 0);
+  context.clearRect(0, 0, logicalWidth, logicalHeight);
 
   // Fill the canvas with the keycap background color
   //context.fillStyle = bgColor;
@@ -162,7 +156,13 @@ const paintKeycap = (
     paintDebugLines(canvas);
   }
 
-  return paintKeycapLabel(canvas, legendColor, label);
+  return paintKeycapLabel(
+    context,
+    logicalWidth,
+    logicalHeight,
+    legendColor,
+    label,
+  );
 };
 
 export const Keycap: React.FC<TwoStringKeycapProps> = React.memo((props) => {


### PR DESCRIPTION
 ## Summary

Fix keycap rendering issues in both the 3D and 2D keyboard views.

## Changes

- Initialize the 3D keycap canvas texture when it is missing before marking it dirty.
- Include `textureOffsetX` in the 3D keycap redraw dependencies.
- Correct non-test pressed/hover keycap state behavior.
- Pass the 2D keycap React `key` explicitly instead of through spread props.
- Update 2D keycap canvas sizing and label painting to use logical dimensions with DPI scaling.

## Cause

3D keycap redraws assumed the texture already existed and did not include texture offset changes as a redraw dependency. This could leave texture updates
incomplete or stale.

The non-test pressed/hover state logic was inverted, which made keycaps use the wrong visual state outside test mode.

The 2D canvas label path mixed physical canvas dimensions with logical drawing dimensions, which produced incorrect scaling on high-DPI displays.

The 2D key group passed `key` through spread props, but React treats `key` as a special prop and does not pass it like a normal component prop.

## Screenshots

Before:

<img width="1920" src="https://github.com/user-attachments/assets/7bed0862-8f18-4e2d-9ee0-76095611e1d7" />


After:

<img width="1920" src="https://github.com/user-attachments/assets/583b1583-78af-4d5e-812c-a166ce7b522c" />