### PR TITLE
Fix multi-line key legends for non-US layouts

### DIFF
--- a/src/components/n-links/keyboard/configure.tsx
+++ b/src/components/n-links/keyboard/configure.tsx
@@ -18,6 +18,8 @@ import {KeyboardCanvas as StringKeyboardCanvas} from '../../two-string/keyboard-
 export const getKeyboardCanvas = (dimension: '2D' | '3D') =>
   dimension === '2D' ? StringKeyboardCanvas : FiberKeyboardCanvas;
 
+const EMPTY_KEYMAP: number[] = [];
+
 export const ConfigureKeyboard = (props: {
   selectable?: boolean;
   dimensions?: DOMRect;
@@ -25,7 +27,7 @@ export const ConfigureKeyboard = (props: {
 }) => {
   const {selectable, dimensions} = props;
   const matrixKeycodes = useAppSelector(
-    (state) => getSelectedKeymap(state) || [],
+    (state) => getSelectedKeymap(state) || EMPTY_KEYMAP,
   );
   const keys: (VIAKey & {ei?: number})[] = useAppSelector(
     getSelectedKeyDefinitions,

--- a/src/components/n-links/keyboard/test.tsx
+++ b/src/components/n-links/keyboard/test.tsx
@@ -28,6 +28,7 @@ import fullKeyboardDefinition from '../../../utils/test-keyboard-definition.json
 import {TestContext} from '../../panes/test';
 import {getKeyboardCanvas} from './configure';
 const EMPTY_ARR = [] as any[];
+const EMPTY_KEYMAP: number[] = [];
 export const Test = (props: {dimensions?: DOMRect; nDimension: NDimension}) => {
   const dispatch = useAppDispatch();
   const [path] = useLocation();
@@ -41,7 +42,7 @@ export const Test = (props: {dimensions?: DOMRect; nDimension: NDimension}) => {
     getTestKeyboardSoundsSettings,
   );
   const selectedMatrixKeycodes = useAppSelector(
-    (state) => getSelectedKeymap(state) || [],
+    (state) => getSelectedKeymap(state) || EMPTY_KEYMAP,
   );
 
   const [globalPressedKeys, setGlobalPressedKeys] = useGlobalKeys(

--- a/src/components/panes/configure-panes/encoder.tsx
+++ b/src/components/panes/configure-panes/encoder.tsx
@@ -32,6 +32,8 @@ const Container = styled.div`
   padding: 0 12px;
 `;
 
+const EMPTY_KEYMAP: number[] = [];
+
 export const Pane: FC = () => {
   const {t} = useTranslation();
   const [cwValue, setCWValue] = useState<number>();
@@ -42,7 +44,7 @@ export const Pane: FC = () => {
     getSelectedKeyDefinitions,
   );
   const matrixKeycodes = useAppSelector(
-    (state) => getSelectedKeymap(state) || [],
+    (state) => getSelectedKeymap(state) || EMPTY_KEYMAP,
   );
   const layer = useAppSelector(getSelectedLayerIndex);
   const selectedDevice = useAppSelector(getSelectedConnectedDevice);

--- a/src/utils/key.ts
+++ b/src/utils/key.ts
@@ -48,10 +48,9 @@ export function isNumpadSymbol(label: string) {
   return label.length === 1 && centeredSymbol.includes(label[0]);
 }
 
-// Test if label is a multi-legend, e.g. "!\n1"
+// Test if label contains two explicitly separated legends, e.g. "!\n1".
 export function isMultiLegend(label: string) {
-  const topLegend = '~!@#$%^&*()_+|{}:"<>?'.split('');
-  return label.length !== 1 && topLegend.includes(label[0]);
+  return /^[^\n]+\n[^\n]+$/.test(label);
 }
 
 // Tests if label is a number

--- a/src/utils/keyboard-rendering.ts
+++ b/src/utils/keyboard-rendering.ts
@@ -503,8 +503,7 @@ export const getLabel = (
       }
     );
   } else if (isMultiLegend(label)) {
-    const topLabel = label[0];
-    const bottomLabel = label[label.length - 1];
+    const [topLabel, bottomLabel] = label.split('\n');
     return (
       bottomLabel && {
         topLabel,


### PR DESCRIPTION
Detect multi-line key legends using their newline separator instead of a US-specific symbol list. This fixes localized layouts such as Italian rendering legends like é/è, ç/ò, and =/0 on one line. English rendering remains unchanged.

It also includes https://github.com/the-via/app/pull/413 w/o the accent range fix.