### PR TITLE
Prevent Cloudflare Pages from serving HTML for stale JS assets

### DIFF
--- a/.github/workflows/deploy-to-cloudflare.yml
+++ b/.github/workflows/deploy-to-cloudflare.yml
@@ -22,6 +22,30 @@ jobs:
         run: bun run refresh-kbs
       - name: Build
         run: bun run build
+      - name: Configure Cloudflare Pages routing
+        run: |
+          cat > dist/_redirects <<'EOF'
+          /test /index.html 200
+          /design /index.html 200
+          /settings /index.html 200
+          /debug /index.html 200
+          /errors /index.html 200
+          EOF
+
+          cat > dist/404.html <<'EOF'
+          <!doctype html>
+          <html lang="en">
+            <head>
+              <meta charset="utf-8" />
+              <meta name="viewport" content="width=device-width, initial-scale=1" />
+              <title>Not Found</title>
+            </head>
+            <body>
+              <h1>Not Found</h1>
+              <p>The requested file could not be found.</p>
+            </body>
+          </html>
+          EOF
       - name: Deploy
         uses: cloudflare/wrangler-action@v3
         with:


### PR DESCRIPTION
This updates the Cloudflare Pages deploy workflow to generate routing control files in `dist` during deployment.

Cloudflare Pages treats sites without a top-level `404.html` as SPAs and serves `index.html` for missing paths. When a browser has stale HTML pointing to an old hashed Vite asset, the missing JS file can receive `index.html` with `text/html`, causing:

```text
Expected a JavaScript-or-Wasm module script but the server responded with a MIME type of "text/html"
```

The workflow now creates:

- `dist/404.html`, so missing asset URLs return a real 404 instead of SPA HTML.
- `dist/_redirects`, so valid app routes like `/design`, `/settings`, `/debug`, `/test`, and `/errors` still resolve to `index.html`.

This keeps the fix deploy-specific without committing `_redirects` or `404.html` into `public`.

## Verification

- Parsed workflow YAML successfully.
- Confirmed generated heredoc content is formatted correctly.
