### PR TITLE
Addition of HID Console Tab

### DIFF
--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -9,7 +9,10 @@ import {TestContext} from './components/panes/test';
 import {useMemo, useState} from 'react';
 import {OVERRIDE_HID_CHECK} from './utils/override';
 import {useAppSelector} from './store/hooks';
-import {getRenderMode} from './store/settingsSlice';
+import {getRenderMode, getShowConsoleTab} from './store/settingsSlice';
+import {useLocation} from 'wouter';
+import {HIDConsole} from './components/panes/hid-console';
+import styled from 'styled-components';
 
 const GlobalStyle = createGlobalStyle`
   *:focus {
@@ -17,13 +20,21 @@ const GlobalStyle = createGlobalStyle`
   }
 `;
 
+const PersistentPane = styled.div<{$active: boolean}>`
+  display: ${({$active}) => ($active ? 'flex' : 'none')};
+  flex: 1;
+  min-height: 0;
+`;
+
 export default () => {
   const hasHIDSupport = 'hid' in navigator || OVERRIDE_HID_CHECK;
 
   const renderMode = useAppSelector(getRenderMode);
+  const showConsoleTab = useAppSelector(getShowConsoleTab);
+  const [location] = useLocation();
   const RouteComponents = useMemo(
     () =>
-      PANES.map((pane) => {
+      PANES.filter((pane) => pane.key !== 'console').map((pane) => {
         return (
           <Route component={pane.component} key={pane.key} path={pane.path} />
         );
@@ -40,7 +51,14 @@ export default () => {
           {hasHIDSupport && <UnconnectedGlobalMenu />}
           <CanvasRouter />
 
-          <Home hasHIDSupport={hasHIDSupport}>{RouteComponents}</Home>
+          <Home hasHIDSupport={hasHIDSupport}>
+            {RouteComponents}
+            {showConsoleTab && (
+              <PersistentPane $active={location === '/console'}>
+                <HIDConsole isActive={location === '/console'} />
+              </PersistentPane>
+            )}
+          </Home>
         </TestContext.Provider>
     </>
   );

--- a/src/components/menus/global.tsx
+++ b/src/components/menus/global.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import {Link, useLocation} from 'wouter';
 import PANES from '../../utils/pane-config';
 import {useAppSelector} from 'src/store/hooks';
-import {getShowDesignTab} from 'src/store/settingsSlice';
+import {getShowConsoleTab, getShowDesignTab} from 'src/store/settingsSlice';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 import {CategoryMenuTooltip} from '../inputs/tooltip';
 import {CategoryIconContainer} from '../panes/grid';
@@ -33,6 +33,7 @@ const GlobalContainer = styled(Container)`
 export const UnconnectedGlobalMenu = () => {
   const {t, i18n} = useTranslation();
   const showDesignTab = useAppSelector(getShowDesignTab);
+  const showConsoleTab = useAppSelector(getShowConsoleTab);
 
   const [location] = useLocation();
 
@@ -40,6 +41,7 @@ export const UnconnectedGlobalMenu = () => {
     return PANES.filter((pane) => pane.key !== ErrorsPaneConfig.key).map(
       (pane) => {
         if (pane.key === 'design' && !showDesignTab) return null;
+        if (pane.key === 'console' && !showConsoleTab) return null;
         if (pane.key === 'debug' && !showDebugPane) return null;
         return (
           <Link key={pane.key} to={pane.path}>
@@ -51,7 +53,7 @@ export const UnconnectedGlobalMenu = () => {
         );
       },
     );
-  }, [location, showDesignTab]);
+  }, [location, showConsoleTab, showDesignTab]);
 
   return (
     <React.Fragment>

--- a/src/components/panes/hid-console.tsx
+++ b/src/components/panes/hid-console.tsx
@@ -1,0 +1,303 @@
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import styled from 'styled-components';
+import {AccentSelect} from '../inputs/accent-select';
+import {Pane} from './pane';
+import {isQMKConsoleDevice, QMK_CONSOLE_FILTER} from 'src/shims/node-hid';
+import {formatNumberAsHex} from 'src/utils/format';
+import {useTranslation} from 'react-i18next';
+import {useAppSelector} from 'src/store/hooks';
+import {
+  getIsSelectedDeviceReady,
+  getSelectedConnectedDevice,
+} from 'src/store/devicesSlice';
+
+const Container = styled.div`
+  box-sizing: border-box;
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 12px;
+  min-height: 0;
+  padding: 20px;
+`;
+
+const Toolbar = styled.div`
+  display: flex;
+  gap: 10px;
+`;
+
+const Console = styled.pre`
+  background: #111;
+  border: 1px solid var(--border_color_cell);
+  border-radius: 4px;
+  box-sizing: border-box;
+  color: #e6e6e6;
+  flex: 1;
+  font:
+    12px/1.45 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    Consolas,
+    monospace;
+  margin: 0;
+  min-height: 0;
+  overflow: auto;
+  padding: 14px;
+  white-space: pre-wrap;
+  word-break: break-word;
+`;
+
+const ActionButton = styled.button`
+  background: var(--bg_menu);
+  border: 1px solid var(--color_accent);
+  border-radius: 4px;
+  color: var(--color_accent);
+  cursor: pointer;
+  padding: 0 18px;
+
+  &:disabled {
+    cursor: default;
+    opacity: 0.45;
+  }
+`;
+
+let sessionOutputs: Record<string, string> = {};
+const deviceKey = (device: HIDDevice) => {
+  return `${device.vendorId}:${device.productId}:${device.productName ?? ''}`;
+};
+
+type HIDConsoleProps = {
+  isActive?: boolean;
+  params?: unknown;
+};
+
+export const HIDConsole = ({isActive = true}: HIDConsoleProps) => {
+  const {t} = useTranslation();
+  const selectedConnectedDevice = useAppSelector(getSelectedConnectedDevice);
+  const isSelectedDeviceReady = useAppSelector(getIsSelectedDeviceReady);
+  const [devices, setDevices] = useState<HIDDevice[]>([]);
+  const [selectedKey, setSelectedKey] = useState<string | null>(null);
+  const [outputs, setOutputs] = useState<Record<string, string>>(
+    sessionOutputs,
+  );
+  const consoleRef = useRef<HTMLPreElement>(null);
+  const lastScopedPath = useRef<string | null>(null);
+  const autoFollowedPath = useRef<string | null>(null);
+  const decoder = useMemo(() => new TextDecoder(), []);
+
+  useEffect(() => {
+    sessionOutputs = outputs;
+  }, [outputs]);
+
+  const refreshDevices = useCallback(async () => {
+    const consoleDevices = (await navigator.hid.getDevices()).filter(
+      isQMKConsoleDevice,
+    );
+    setDevices(consoleDevices);
+    setSelectedKey((current) =>
+      current && consoleDevices.some((device) => deviceKey(device) === current)
+        ? current
+        : null,
+    );
+  }, []);
+
+  useEffect(() => {
+    refreshDevices();
+    navigator.hid.addEventListener('connect', refreshDevices);
+    navigator.hid.addEventListener('disconnect', refreshDevices);
+    return () => {
+      navigator.hid.removeEventListener('connect', refreshDevices);
+      navigator.hid.removeEventListener('disconnect', refreshDevices);
+    };
+  }, [refreshDevices]);
+
+  useEffect(() => {
+    const scopedPath = selectedConnectedDevice?.path ?? null;
+    if (lastScopedPath.current !== scopedPath) {
+      lastScopedPath.current = scopedPath;
+      autoFollowedPath.current = null;
+      setSelectedKey(null);
+    }
+  }, [selectedConnectedDevice?.path]);
+
+  useEffect(() => {
+    if (!selectedConnectedDevice || !isSelectedDeviceReady) {
+      return;
+    }
+    if (autoFollowedPath.current === selectedConnectedDevice.path) return;
+
+    const consoleDevice = devices.find(
+      (device) =>
+        device.vendorId === selectedConnectedDevice.vendorId &&
+        device.productId === selectedConnectedDevice.productId,
+    );
+    if (consoleDevice) {
+      setSelectedKey(deviceKey(consoleDevice));
+      autoFollowedPath.current = selectedConnectedDevice.path;
+    }
+  }, [devices, isSelectedDeviceReady, selectedConnectedDevice]);
+
+  const selectedDevice = devices.find(
+    (device) => deviceKey(device) === selectedKey,
+  );
+
+  useEffect(() => {
+    if (!selectedDevice) return;
+
+    let cancelled = false;
+
+    const handleReport = (event: HIDInputReportEvent) => {
+      const bytes = new Uint8Array(
+        event.data.buffer,
+        event.data.byteOffset,
+        event.data.byteLength,
+      );
+      const text = decoder.decode(bytes).replaceAll('\0', '');
+      if (text) {
+        setOutputs((current) => ({
+          ...current,
+          [selectedKey as string]:
+            (current[selectedKey as string] ?? '') + text,
+        }));
+      }
+    };
+
+    const startListening = async () => {
+      try {
+        if (!selectedDevice.opened) await selectedDevice.open();
+        if (!cancelled) {
+          selectedDevice.addEventListener('inputreport', handleReport);
+        }
+      } catch (error) {
+        if (!cancelled) {
+          const message = error instanceof Error ? error.message : String(error);
+          setOutputs((current) => ({
+            ...current,
+            [selectedKey as string]: `[Unable to open HID console: ${message}]\n`,
+          }));
+        }
+      }
+    };
+
+    startListening();
+    return () => {
+      cancelled = true;
+      selectedDevice.removeEventListener('inputreport', handleReport);
+    };
+  }, [decoder, selectedDevice, selectedKey]);
+
+  const output = selectedKey ? (outputs[selectedKey] ?? '') : '';
+
+  useLayoutEffect(() => {
+    if (isActive && consoleRef.current) {
+      consoleRef.current.scrollTo({
+        top: consoleRef.current.scrollHeight,
+        behavior: 'auto',
+      });
+    }
+  }, [isActive, output, selectedKey]);
+
+  const options = devices.map((device) => ({
+    value: deviceKey(device),
+    label: `${device.productName || t('Unnamed device')} (${formatNumberAsHex(device.vendorId, 4)}:${formatNumberAsHex(device.productId, 4)})`,
+  }));
+
+  const authorizeDevice = async () => {
+    try {
+      const requestedDevices = await navigator.hid.requestDevice({
+        filters: [QMK_CONSOLE_FILTER],
+      });
+      const consoleDevice = requestedDevices.find(isQMKConsoleDevice);
+      if (!consoleDevice) return;
+
+      setDevices((current) => [
+        ...current.filter(
+          (candidate) => deviceKey(candidate) !== deviceKey(consoleDevice),
+        ),
+        consoleDevice,
+      ]);
+      setSelectedKey(deviceKey(consoleDevice));
+    } catch (error) {
+      // Cancelling the browser's device picker leaves the current selection alone.
+      if (error instanceof DOMException && error.name === 'NotFoundError') return;
+      const message = error instanceof Error ? error.message : String(error);
+      setOutputs((current) => ({
+        ...current,
+        authorization: `[Unable to authorize HID console: ${message}]\n`,
+      }));
+      setSelectedKey('authorization');
+    }
+  };
+
+  const save = () => {
+    if (!selectedDevice) return;
+
+    const exportedAt = new Date();
+    const vendorId = formatNumberAsHex(selectedDevice.vendorId, 4);
+    const productId = formatNumberAsHex(selectedDevice.productId, 4);
+    const header = [
+      'HID Console Log',
+      `Board: ${selectedDevice.productName || 'Unnamed device'}`,
+      `Vendor ID: ${vendorId}`,
+      `Product ID: ${productId}`,
+      `Device ID: ${vendorId}:${productId}`,
+      `Exported: ${exportedAt.toISOString()}`,
+      '',
+      '--- Console Output ---',
+      '',
+    ].join('\n');
+    const url = URL.createObjectURL(
+      new Blob([header, output], {type: 'text/plain'}),
+    );
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = `hid-console-${exportedAt.toISOString().replaceAll(':', '-')}.txt`;
+    anchor.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <Pane>
+      <Container>
+        <Toolbar>
+          <AccentSelect
+            value={
+              options.find((option) => option.value === selectedKey) ?? null
+            }
+            options={options}
+            placeholder={
+              options.length
+                ? t('Select console device')
+                : t('No console device connected')
+            }
+            isDisabled={!options.length}
+            onChange={(option: any) => setSelectedKey(option?.value ?? null)}
+          />
+          <ActionButton onClick={authorizeDevice}>
+            {t('Add device')}
+          </ActionButton>
+          <ActionButton
+            onClick={() =>
+              selectedKey &&
+              setOutputs((current) => ({...current, [selectedKey]: ''}))
+            }
+            disabled={!output}
+          >
+            {t('Clear')}
+          </ActionButton>
+          <ActionButton onClick={save} disabled={!output}>
+            {t('Save')}
+          </ActionButton>
+        </Toolbar>
+        <Console ref={consoleRef}>{output}</Console>
+      </Container>
+    </Pane>
+  );
+};

--- a/src/components/panes/settings.tsx
+++ b/src/components/panes/settings.tsx
@@ -16,10 +16,12 @@ import {useDispatch} from 'react-redux';
 import {useAppSelector} from 'src/store/hooks';
 import {
   getShowDesignTab,
+  getShowConsoleTab,
   getShowDesignTabConfirmationNotice,
   getDisableFastRemap,
   getShowSliderValuesMode,
   toggleCreatorMode,
+  toggleConsoleTab,
   toggleFastRemap,
   updateShowSliderValuesMode,
   getThemeMode,
@@ -63,6 +65,7 @@ export const Settings = () => {
   const {t} = useTranslation();
   const dispatch = useDispatch();
   const showDesignTab = useAppSelector(getShowDesignTab);
+  const showConsoleTab = useAppSelector(getShowConsoleTab);
   const showDesignTabConfirmationNotice = useAppSelector(
     getShowDesignTabConfirmationNotice,
   );
@@ -147,6 +150,15 @@ export const Settings = () => {
                 <AccentSlider
                   onChange={() => dispatch(toggleCreatorMode())}
                   isChecked={showDesignTab}
+                />
+              </Detail>
+            </ControlRow>
+            <ControlRow>
+              <Label>{t('Show HID Console tab')}</Label>
+              <Detail>
+                <AccentSlider
+                  onChange={() => dispatch(toggleConsoleTab())}
+                  isChecked={showConsoleTab}
                 />
               </Detail>
             </ControlRow>

--- a/src/components/three-fiber/canvas-router.tsx
+++ b/src/components/three-fiber/canvas-router.tsx
@@ -112,7 +112,7 @@ export const NonSuspenseCanvasRouter = () => {
   const showAuthorizeButton = 'hid' in navigator || OVERRIDE_HID_CHECK;
   const hideCanvasScene =
     !showAuthorizeButton ||
-    ['/settings', '/errors'].includes(path) ||
+    ['/settings', '/errors', '/console'].includes(path) ||
     hideDesignScene ||
     hideConfigureScene;
   const configureKeyboardIsSelectable = useAppSelector(

--- a/src/components/two-string/canvas-router.tsx
+++ b/src/components/two-string/canvas-router.tsx
@@ -92,7 +92,7 @@ export const CanvasRouter = () => {
   const showAuthorizeButton = 'hid' in navigator || OVERRIDE_HID_CHECK;
   const hideCanvasScene =
     !showAuthorizeButton ||
-    ['/settings', '/errors'].includes(path) ||
+    ['/settings', '/errors', '/console'].includes(path) ||
     hideDesignScene ||
     hideConfigureScene;
   const configureKeyboardIsSelectable = useAppSelector(

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -364,5 +364,6 @@
   "VIA could not find a {{definitionVersion}} definition for {{deviceName}}.\nVID: {{vid}} | PID: {{pid}}\n\nThis means that:\n- this keyboard is not officially supported through the remote definition database\n- the definition file of the keyboard has not been sideloaded through the Design tab\n\nPlease contact your keyboard's manufacturer or vendor to add it to the database, or upload the JSON definition provided by your keyboard's manufacturer or vendor in the Design tab.": "VIA konnte keine {{definitionVersion}}-Definition für {{deviceName}} finden.\nVID: {{vid}} | PID: {{pid}}\n\nDas bedeutet:\n- Diese Tastatur wird nicht offiziell über die Remote-Definitionsdatenbank unterstützt\n- Die Definitionsdatei dieser Tastatur wurde nicht über den Design-Reiter sideloaded\n\nBitte den Hersteller oder Händler Ihrer Tastatur kontaktieren, damit sie zur Datenbank hinzugefügt wird, oder die vom Hersteller oder Händler Ihrer Tastatur bereitgestellte JSON-Definition im Design-Reiter hochladen.",
   "this device": "dieses Gerät",
   "this keyboard": "diese Tastatur",
-  "You didn't click \"Confirm\". To enable the Design tab, you must confirm first.": "Du hast nicht auf \"Bestätigen\" geklickt. Um den Design-Reiter zu aktivieren, musst du zuerst bestätigen."
+  "You didn't click \"Confirm\". To enable the Design tab, you must confirm first.": "Du hast nicht auf \"Bestätigen\" geklickt. Um den Design-Reiter zu aktivieren, musst du zuerst bestätigen.",
+  "Add device": "Gerät hinzufügen"
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -364,5 +364,6 @@
   "VIA could not find a {{definitionVersion}} definition for {{deviceName}}.\nVID: {{vid}} | PID: {{pid}}\n\nThis means that:\n- this keyboard is not officially supported through the remote definition database\n- the definition file of the keyboard has not been sideloaded through the Design tab\n\nPlease contact your keyboard's manufacturer or vendor to add it to the database, or upload the JSON definition provided by your keyboard's manufacturer or vendor in the Design tab.": "VIA could not find a {{definitionVersion}} definition for {{deviceName}}.\nVID: {{vid}} | PID: {{pid}}\n\nThis means that:\n- this keyboard is not officially supported through the remote definition database\n- the definition file of the keyboard has not been sideloaded through the Design tab\n\nPlease contact your keyboard's manufacturer or vendor to add it to the database, or upload the JSON definition provided by your keyboard's manufacturer or vendor in the Design tab.",
   "this device": "this device",
   "this keyboard": "this keyboard",
-  "You didn't click \"Confirm\". To enable the Design tab, you must confirm first.": "You didn't click \"Confirm\". To enable the Design tab, you must confirm first."
+  "You didn't click \"Confirm\". To enable the Design tab, you must confirm first.": "You didn't click \"Confirm\". To enable the Design tab, you must confirm first.",
+  "Add device": "Add device"
 }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -364,5 +364,6 @@
   "VIA could not find a {{definitionVersion}} definition for {{deviceName}}.\nVID: {{vid}} | PID: {{pid}}\n\nThis means that:\n- this keyboard is not officially supported through the remote definition database\n- the definition file of the keyboard has not been sideloaded through the Design tab\n\nPlease contact your keyboard's manufacturer or vendor to add it to the database, or upload the JSON definition provided by your keyboard's manufacturer or vendor in the Design tab.": "VIA no pudo encontrar una definición {{definitionVersion}} para {{deviceName}}.\nVID: {{vid}} | PID: {{pid}}\n\nEsto significa que:\n- este teclado no es compatible oficialmente mediante la base de datos remota de definiciones\n- el archivo de definición del teclado no se ha cargado manualmente desde la pestaña Diseño\n\nContacta al fabricante o vendedor de tu teclado para que lo agregue a la base de datos, o sube en la pestaña Diseño la definición JSON proporcionada por el fabricante o vendedor de tu teclado.",
   "this device": "este dispositivo",
   "this keyboard": "este teclado",
-  "You didn't click \"Confirm\". To enable the Design tab, you must confirm first.": "No hiciste clic en \"Confirmar\". Para habilitar la pestaña Diseño, primero debes confirmar."
+  "You didn't click \"Confirm\". To enable the Design tab, you must confirm first.": "No hiciste clic en \"Confirmar\". Para habilitar la pestaña Diseño, primero debes confirmar.",
+  "Add device": "Añadir dispositivo"
 }

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -364,5 +364,6 @@
   "VIA could not find a {{definitionVersion}} definition for {{deviceName}}.\nVID: {{vid}} | PID: {{pid}}\n\nThis means that:\n- this keyboard is not officially supported through the remote definition database\n- the definition file of the keyboard has not been sideloaded through the Design tab\n\nPlease contact your keyboard's manufacturer or vendor to add it to the database, or upload the JSON definition provided by your keyboard's manufacturer or vendor in the Design tab.": "VIA は {{deviceName}} の {{definitionVersion}} 定義を見つけられませんでした。\nVID: {{vid}} | PID: {{pid}}\n\nこれは次を意味します:\n- このキーボードはリモート定義データベースで公式にサポートされていません\n- このキーボードの定義ファイルはデザインタブからサイドロードされていません\n\nデータベースへの追加についてキーボードのメーカーまたは販売元に問い合わせるか、メーカーまたは販売元から提供された JSON 定義をデザインタブでアップロードしてください。",
   "this device": "このデバイス",
   "this keyboard": "このキーボード",
-  "You didn't click \"Confirm\". To enable the Design tab, you must confirm first.": "\"確認\"をクリックしていません。デザインタブを有効にするには、先に確認が必要です。"
+  "You didn't click \"Confirm\". To enable the Design tab, you must confirm first.": "\"確認\"をクリックしていません。デザインタブを有効にするには、先に確認が必要です。",
+  "Add device": "デバイスを追加"
 }

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -364,5 +364,6 @@
   "VIA could not find a {{definitionVersion}} definition for {{deviceName}}.\nVID: {{vid}} | PID: {{pid}}\n\nThis means that:\n- this keyboard is not officially supported through the remote definition database\n- the definition file of the keyboard has not been sideloaded through the Design tab\n\nPlease contact your keyboard's manufacturer or vendor to add it to the database, or upload the JSON definition provided by your keyboard's manufacturer or vendor in the Design tab.": "VIA에서 {{deviceName}}의 {{definitionVersion}} 정의를 찾지 못했습니다.\nVID: {{vid}} | PID: {{pid}}\n\n이는 다음을 의미합니다:\n- 이 키보드는 원격 정의 데이터베이스를 통해 공식적으로 지원되지 않습니다\n- 이 키보드의 정의 파일은 디자인 탭을 통해 사이드로드되지 않았습니다\n\n데이터베이스 추가를 위해 키보드 제조사 또는 판매처에 문의하거나, 키보드 제조사 또는 판매처가 제공한 JSON 정의를 디자인 탭에서 업로드하세요.",
   "this device": "이 장치",
   "this keyboard": "이 키보드",
-  "You didn't click \"Confirm\". To enable the Design tab, you must confirm first.": "\"확인\"을 클릭하지 않았습니다. 디자인 탭을 활성화하려면 먼저 확인해야 합니다."
+  "You didn't click \"Confirm\". To enable the Design tab, you must confirm first.": "\"확인\"을 클릭하지 않았습니다. 디자인 탭을 활성화하려면 먼저 확인해야 합니다.",
+  "Add device": "장치 추가"
 }

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -364,5 +364,6 @@
   "VIA could not find a {{definitionVersion}} definition for {{deviceName}}.\nVID: {{vid}} | PID: {{pid}}\n\nThis means that:\n- this keyboard is not officially supported through the remote definition database\n- the definition file of the keyboard has not been sideloaded through the Design tab\n\nPlease contact your keyboard's manufacturer or vendor to add it to the database, or upload the JSON definition provided by your keyboard's manufacturer or vendor in the Design tab.": "VIA 找不到 {{deviceName}} 的 {{definitionVersion}} 定义。\nVID: {{vid}} | PID: {{pid}}\n\n这意味着：\n- 此键盘未通过远程定义数据库获得官方支持\n- 此键盘的定义文件尚未通过“设计”标签页侧载\n\n请联系键盘制造商或供应商将其添加到数据库，或在“设计”标签页上传键盘制造商或供应商提供的 JSON 定义。",
   "this device": "此设备",
   "this keyboard": "此键盘",
-  "You didn't click \"Confirm\". To enable the Design tab, you must confirm first.": "你没有点击“确认”。要启用“设计”标签页，必须先确认。"
+  "You didn't click \"Confirm\". To enable the Design tab, you must confirm first.": "你没有点击“确认”。要启用“设计”标签页，必须先确认。",
+  "Add device": "添加设备"
 }

--- a/src/shims/node-hid.ts
+++ b/src/shims/node-hid.ts
@@ -24,6 +24,18 @@ const filterHIDDevices = (devices: HIDDevice[]) =>
     ),
   );
 
+export const QMK_CONSOLE_FILTER = {
+  usagePage: 0xff31,
+  usage: 0x74,
+};
+
+export const isQMKConsoleDevice = (device: HIDDevice) =>
+  device.collections?.some(
+    (collection) =>
+      collection.usage === QMK_CONSOLE_FILTER.usage &&
+      collection.usagePage === QMK_CONSOLE_FILTER.usagePage,
+  ) ?? false;
+
 const getVIAPathIdentifier = () =>
   (self.crypto && self.crypto.randomUUID && self.crypto.randomUUID()) ||
   `via-path:${Math.random()}`;
@@ -64,10 +76,12 @@ const ExtendedHID = {
           usagePage: 0xff60,
           usage: 0x61,
         },
+        QMK_CONSOLE_FILTER,
       ],
     });
-    requestedDevice.forEach(tagDevice);
-    return requestedDevice[0];
+    const viaDevices = filterHIDDevices(requestedDevice);
+    viaDevices.forEach(tagDevice);
+    return viaDevices[0];
   },
   getFilteredDevices: async () => {
     try {

--- a/src/store/devicesSlice.ts
+++ b/src/store/devicesSlice.ts
@@ -14,6 +14,7 @@ import type {RootState} from './index';
 
 type DevicesState = {
   selectedDevicePath: string | null;
+  readyDevicePath: string | null;
   connectedDevicePaths: ConnectedDevices;
   unresolvedDefinitionDevicePaths: AuthorizedDevices;
   invalidProtocolDevicePaths: Record<string, Device>;
@@ -23,6 +24,7 @@ type DevicesState = {
 
 const initialState: DevicesState = {
   selectedDevicePath: null,
+  readyDevicePath: null,
   connectedDevicePaths: {},
   unresolvedDefinitionDevicePaths: {},
   invalidProtocolDevicePaths: {},
@@ -36,10 +38,16 @@ const deviceSlice = createSlice({
   reducers: {
     // TODO: change to just pass the device path instead of the whole device
     selectDevice: (state, action: PayloadAction<ConnectedDevice | null>) => {
+      state.readyDevicePath = null;
       if (!action.payload) {
         state.selectedDevicePath = null;
       } else {
         state.selectedDevicePath = action.payload.path;
+      }
+    },
+    markDeviceReady: (state, action: PayloadAction<string>) => {
+      if (state.selectedDevicePath === action.payload) {
+        state.readyDevicePath = action.payload;
       }
     },
     setForceAuthorize: (state, action: PayloadAction<boolean>) => {
@@ -74,6 +82,7 @@ const deviceSlice = createSlice({
     },
     clearAllDevices: (state) => {
       state.selectedDevicePath = null;
+      state.readyDevicePath = null;
       state.connectedDevicePaths = {};
       state.unresolvedDefinitionDevicePaths = {};
       state.invalidProtocolDevicePaths = {};
@@ -98,6 +107,7 @@ const deviceSlice = createSlice({
 export const {
   clearAllDevices,
   selectDevice,
+  markDeviceReady,
   updateConnectedDevices,
   updateUnresolvedDefinitionDevices,
   dismissUnresolvedDefinitionDevice,
@@ -128,11 +138,14 @@ export const getInvalidProtocolDeviceWarning = createSelector(
 );
 export const getSelectedDevicePath = (state: RootState) =>
   state.devices.selectedDevicePath;
+export const getIsSelectedDeviceReady = (state: RootState) =>
+  state.devices.selectedDevicePath !== null &&
+  state.devices.readyDevicePath === state.devices.selectedDevicePath;
 export const getSupportedIds = (state: RootState) => state.devices.supportedIds;
 export const getSelectedConnectedDevice = createSelector(
   getConnectedDevices,
   getSelectedDevicePath,
-  (devices, path) => path && devices[path],
+  (devices, path) => (path ? devices[path] : null),
 );
 export const getSelectedKeyboardAPI = createSelector(
   getSelectedDevicePath,

--- a/src/store/devicesThunks.ts
+++ b/src/store/devicesThunks.ts
@@ -26,6 +26,7 @@ import {
   getSelectedDevicePath,
   getSupportedIds,
   selectDevice,
+  markDeviceReady,
   setForceAuthorize,
   updateConnectedDevices,
   updateInvalidProtocolDevices,
@@ -92,6 +93,7 @@ const selectConnectedDevice =
 
       // John you drongo, don't trust the compiler, dispatches are totes awaitable for async thunks
       await dispatch(loadKeymapFromDevice(connectedDevice));
+      dispatch(markDeviceReady(connectedDevice.path));
       selectConnectedDeviceRetry.clear();
     } catch (e) {
       if (selectConnectedDeviceRetry.retriesLeft()) {

--- a/src/store/settingsSlice.ts
+++ b/src/store/settingsSlice.ts
@@ -56,6 +56,9 @@ const settingsSlice = createSlice({
     toggleCreatorMode: (state) => {
       toggleBool(state, 'showDesignTab');
     },
+    toggleConsoleTab: (state) => {
+      toggleBool(state, 'showConsoleTab');
+    },
     setShowDesignTab: (state, action: PayloadAction<boolean>) => {
       state.showDesignTab = action.payload;
       setSettings(state);
@@ -127,6 +130,7 @@ export const {
   toggleFastRemap,
   updateShowSliderValuesMode,
   toggleCreatorMode,
+  toggleConsoleTab,
   setShowDesignTab,
   setTestMatrixEnabled,
   setShowDesignTabConfirmationNotice,
@@ -153,6 +157,8 @@ export const getShowSliderValuesMode = (state: RootState) =>
   webGLIsAvailable ? state.settings.ShowSliderValuesMode : 'Slider Only';
 export const getShowDesignTab = (state: RootState) =>
   state.settings.showDesignTab;
+export const getShowConsoleTab = (state: RootState) =>
+  state.settings.showConsoleTab;
 export const getShowDesignTabConfirmationNotice = (state: RootState) =>
   state.settings.showDesignTabConfirmationNotice;
 export const getRestartRequired = (state: RootState) =>

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -83,6 +83,7 @@ export type TestKeyboardSoundsSettings = {
 
 export type Settings = {
   showDesignTab: boolean;
+  showConsoleTab: boolean;
   disableFastRemap: boolean;
   ShowSliderValuesMode: 'Slider Only' | 'Slider & Show Value' | 'Slider & Input Field';
   renderMode: '3D' | '2D';

--- a/src/utils/device-store.ts
+++ b/src/utils/device-store.ts
@@ -29,6 +29,7 @@ const defaultStoreData = {
   definitions: {},
   settings: {
     showDesignTab: false,
+    showConsoleTab: false,
     disableFastRemap: false,
     ShowSliderValuesMode: 'Slider Only' as const,
     renderMode: '2D' as const,

--- a/src/utils/pane-config.ts
+++ b/src/utils/pane-config.ts
@@ -1,6 +1,7 @@
 import {
   faBrush,
   faBug,
+  faTerminal,
   faGear,
   faKeyboard,
   faStethoscope,
@@ -11,6 +12,7 @@ import {DesignTab} from '../components/panes/design';
 import {Settings} from '../components/panes/settings';
 import {Test} from '../components/panes/test';
 import {ErrorsPaneConfig} from '../components/panes/errors';
+import {HIDConsole} from '../components/panes/hid-console';
 
 export default [
   {
@@ -33,6 +35,13 @@ export default [
     icon: faBrush,
     path: '/design',
     title: 'Design',
+  },
+  {
+    key: 'console',
+    component: HIDConsole,
+    icon: faTerminal,
+    path: '/console',
+    title: 'HID Console',
   },
   {
     key: 'settings',


### PR DESCRIPTION
Adds an optional read-only HID Console to VIA for viewing output from QMK-compatible boards directly in the application.

The console can be enabled from Settings, similar to the Design tab.

## Features

- Adds a dedicated HID Console tab.
- Detects QMK console interfaces using usage page `0xFF31` and usage `0x74`.
- Automatically follows the device currently selected in VIA.
- Waits until VIA has finished initializing the selected device before attaching the console listener.
- Keeps listening while navigating between VIA tabs.
- Supports manually selecting another authorized console device.
- Adds an **Add device** button for authorizing console-enabled devices that do not support VIA.
- Maintains separate console output buffers for each device.
- Automatically scrolls to the latest output:
  - when new output arrives;
  - when returning to the Console tab;
  - when switching devices.
- Provides Clear and Save actions.
- Exports logs as timestamped `.txt` files with:
  - board name;
  - vendor ID
  - product ID
  - combined device ID
  - export timestamp

## Device selection behavior

- If the currently selected VIA board has an authorized console interface, it is selected automatically.
- Changing the selected VIA board updates the automatic console selection.
- A different authorized console device can be selected manually.
- Manually selected devices remain selected until VIA’s scoped device changes.
- Non-VIA QMK console devices can be authorized with **Add device**.

## Implementation notes

- The console is mounted persistently while enabled so HID output is not lost when navigating between tabs.
- Console reports are handled through their own WebHID listener and do not consume VIA response events.
- A device-readiness state prevents the console from attaching during VIA’s initial protocol, macro, lighting, menu, firmware, and keymap requests.
- Console visibility remains configurable and is persisted with the other application settings.

## Limitations

WebHID does not expose a stable serial number or equivalent identifier. Multiple identical boards with the same VID, PID, and product name may therefore be difficult to distinguish reliably.

## Validation

- [x] TypeScript compilation passes
- [x] Production build passes
- [x] Diff whitespace checks pass
- [x] Tested device authorization and console output
- [x] Tested navigation while console output is active
- [x] Tested automatic and manual device selection
- [x] Tested clearing and exporting console output