### PR TITLE
Fix custom range controls dropping extended command arguments

### DIFF
--- a/src/store/menusSlice.ts
+++ b/src/store/menusSlice.ts
@@ -22,6 +22,7 @@ import {isCustomMenuCommandContent} from 'src/utils/custom-menu';
 import {
   collectRangeControls,
   decodeRangeValue,
+  encodeRangeCommand,
   encodeRangeValue,
   resolveRangeChange,
 } from 'src/utils/range-constraints';
@@ -178,9 +179,13 @@ export const updateCustomMenuRangeValue =
 
     const channels = new Set<number>();
     for (const [id, value] of updates) {
-      const [, channel, commandId] = rangeControls[id].content;
-      const bytes = encodeRangeValue(value, rangeControls[id].options[1]);
-      await api.setCustomMenuValue(channel, commandId, ...bytes);
+      const command = encodeRangeCommand(
+        rangeControls[id].content,
+        value,
+        rangeControls[id].options[1],
+      );
+      const channel = command[0];
+      await api.setCustomMenuValue(...command);
       channels.add(channel);
     }
     for (const channel of channels) {

--- a/src/utils/range-constraints.ts
+++ b/src/utils/range-constraints.ts
@@ -15,6 +15,15 @@ export const decodeRangeValue = (value: number[], max: number) =>
 export const encodeRangeValue = (value: number, max: number) =>
   max > 255 ? [value >> 8, value & 255] : [value];
 
+export const encodeRangeCommand = (
+  content: readonly [string, number, number, ...number[]],
+  value: number,
+  max: number,
+) => {
+  const [, ...command] = content;
+  return [...command, ...encodeRangeValue(value, max)];
+};
+
 const clamp = (value: number, min: number, max: number) =>
   Math.min(Math.max(value, min), max);
 


### PR DESCRIPTION
## Summary

Preserve all custom-menu command arguments when updating range controls.

The range update path previously extracted only the channel and command ID, dropping additional command arguments such as a layer or item index.

For a control defined as:

```json
["id_custom_slider_id", 0, 2, 4]
```

changing its value to `7` incorrectly sent:

```text
channel=0, command=2, value=7
```

instead of:

```text
channel=0, command=2, layer=4, value=7
```

Firmware expecting the extended argument could therefore update the wrong setting or interpret the value as an index.

## Fix

Range SET commands now:

1. Remove only the UI identifier.
2. Preserve every remaining command argument.
3. Append the encoded one-byte or multi-byte value.

## Tests

Added regression coverage confirming that:

- Additional command parameters are preserved for one-byte range values.
- Additional command parameters are preserved for multi-byte range values.

## Verification

- `npm test`
- `npx tsc --noEmit`
- Prettier check