### PR TITLE
Add dynamic board names using custom VIA values

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
         "@react-three/fiber": "^8.17.9",
         "@reduxjs/toolkit": "^2.3.0",
         "@the-via/pelpi": "^0.0.3",
-        "@the-via/reader": "^1.14.1",
+        "@the-via/reader": "^1.14.2",
         "@webscopeio/react-textarea-autocomplete": "^4.9.2",
         "downshift": "^7.2.1",
         "i18next": "^23.10.1",
@@ -457,7 +457,7 @@
 
     "@the-via/pelpi": ["@the-via/pelpi@0.0.3", "", { "dependencies": { "chalk": "^4.1.0" } }, "sha512-an6Flsgza6BuvuN+hcD+clefZDc7ncQT1iyEJOLcQc8VunRMwXy+1jsoxAuJLJKZGcGh17EKuKjQK4a6zUgUAg=="],
 
-    "@the-via/reader": ["@the-via/reader@1.14.1", "", { "dependencies": { "ajv": "^8.18.0", "ajv-formats": "^3.0.1", "invariant": "^2.2.4" } }, "sha512-3avOq2x/kJmEZkJIj87SQDnGXIEQ4rHRO4T3vDF1Kcy3F2UqxYvpuPTdLOs8miZqX6bgpsJKMCQFFNWdtmsoAA=="],
+    "@the-via/reader": ["@the-via/reader@1.14.2", "", { "dependencies": { "ajv": "^8.18.0", "ajv-formats": "^3.0.1", "invariant": "^2.2.4" } }, "sha512-GSHmfy1HEuwwx0+IOzVDFpgFaZZV5hbGynw1tiB2+CqLPknJpEH7iQOu16eZ6gahGhFaHgIAj8jS1PwPLedhJQ=="],
 
     "@tweenjs/tween.js": ["@tweenjs/tween.js@23.1.3", "", {}, "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA=="],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@react-three/fiber": "^8.17.9",
         "@reduxjs/toolkit": "^2.3.0",
         "@the-via/pelpi": "^0.0.3",
-        "@the-via/reader": "^1.14.1",
+        "@the-via/reader": "^1.14.2",
         "@webscopeio/react-textarea-autocomplete": "^4.9.2",
         "downshift": "^7.2.1",
         "i18next": "^23.10.1",
@@ -2930,9 +2930,9 @@
       }
     },
     "node_modules/@the-via/reader": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@the-via/reader/-/reader-1.14.1.tgz",
-      "integrity": "sha512-3avOq2x/kJmEZkJIj87SQDnGXIEQ4rHRO4T3vDF1Kcy3F2UqxYvpuPTdLOs8miZqX6bgpsJKMCQFFNWdtmsoAA==",
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/@the-via/reader/-/reader-1.14.2.tgz",
+      "integrity": "sha512-GSHmfy1HEuwwx0+IOzVDFpgFaZZV5hbGynw1tiB2+CqLPknJpEH7iQOu16eZ6gahGhFaHgIAj8jS1PwPLedhJQ==",
       "license": "GPL-3.0",
       "dependencies": {
         "ajv": "^8.18.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@react-three/fiber": "^8.17.9",
     "@reduxjs/toolkit": "^2.3.0",
     "@the-via/pelpi": "^0.0.3",
-    "@the-via/reader": "^1.14.1",
+    "@the-via/reader": "^1.14.2",
     "@webscopeio/react-textarea-autocomplete": "^4.9.2",
     "downshift": "^7.2.1",
     "i18next": "^23.10.1",

--- a/src/components/panes/configure-panes/badge.tsx
+++ b/src/components/panes/configure-panes/badge.tsx
@@ -17,6 +17,10 @@ import {
 import {selectConnectedDeviceByPath} from 'src/store/devicesThunks';
 import {isElectron} from 'src/utils/running-context';
 import {useTranslation} from 'react-i18next';
+import {
+  getConnectedDefinitionNames,
+  getSelectedDefinitionName,
+} from 'src/store/definitionNameSlice';
 
 const Container = styled.div`
   position: absolute;
@@ -107,7 +111,11 @@ const ClickCover = styled.div`
   background: rgba(0, 0, 0, 0.75);
 `;
 
-type ConnectedKeyboardDefinition = [string, VIADefinitionV2 | VIADefinitionV3];
+type ConnectedKeyboardDefinition = [
+  string,
+  VIADefinitionV2 | VIADefinitionV3,
+  string,
+];
 
 const KeyboardSelectors: React.FC<{
   show: boolean;
@@ -127,14 +135,14 @@ const KeyboardSelectors: React.FC<{
     <>
       {props.show && <ClickCover onClick={props.onClickOut} />}
       <KeyboardList $show={props.show}>
-        {props.keyboards.map(([path, keyboard]) => {
+        {props.keyboards.map(([path, , name]) => {
           return (
             <KeyboardButton
               $selected={path === props.selectedPath}
               key={path}
               onClick={() => props.selectKeyboard(path as string)}
             >
-              {keyboard.name}
+              {name}
             </KeyboardButton>
           );
         })}
@@ -153,6 +161,10 @@ export const Badge = () => {
   const dispatch = useAppDispatch();
   const definitions = useAppSelector(getDefinitions);
   const selectedDefinition = useAppSelector(getSelectedDefinition);
+  const selectedDefinitionName = useAppSelector(getSelectedDefinitionName);
+  const getConnectedDefinitionName = useAppSelector(
+    getConnectedDefinitionNames,
+  );
   const connectedDevices = useAppSelector(getConnectedDevices);
   const selectedPath = useAppSelector(getSelectedDevicePath);
   const [showList, setShowList] = useState(false);
@@ -160,15 +172,19 @@ export const Badge = () => {
   const connectedKeyboardDefinitions: ConnectedKeyboardDefinition[] = useMemo(
     () =>
       Object.entries(connectedDevices)
-        .map<ConnectedKeyboardDefinition>(([path, device]) => [
-          path,
-          definitions[(device as ConnectedDevice).vendorProductId] &&
-            definitions[(device as ConnectedDevice).vendorProductId][
-              (device as ConnectedDevice).requiredDefinitionVersion
-            ],
-        ])
+        .map<ConnectedKeyboardDefinition>(([path, device]) => {
+          const connectedDevice = device as ConnectedDevice;
+          return [
+            path,
+            definitions[connectedDevice.vendorProductId] &&
+              definitions[connectedDevice.vendorProductId][
+                connectedDevice.requiredDefinitionVersion
+              ],
+            getConnectedDefinitionName(connectedDevice),
+          ];
+        })
         .filter((i) => i[1]),
-    [connectedDevices, definitions],
+    [connectedDevices, definitions, getConnectedDefinitionName],
   );
 
   if (!selectedDefinition || !selectedPath) {
@@ -179,7 +195,7 @@ export const Badge = () => {
     <>
       <Container>
         <KeyboardTitle onClick={() => setShowList(!showList)}>
-          {selectedDefinition.name}
+          {selectedDefinitionName}
           <FontAwesomeIcon
             icon={faAngleDown}
             style={{

--- a/src/components/panes/configure-panes/save-load.tsx
+++ b/src/components/panes/configure-panes/save-load.tsx
@@ -24,6 +24,7 @@ import {
 } from 'src/store/devicesSlice';
 import {getExpressions, saveMacros} from 'src/store/macrosSlice';
 import {useTranslation} from 'react-i18next';
+import {getSelectedDefinitionName} from 'src/store/definitionNameSlice';
 
 type ViaSaveFile = {
   name: string;
@@ -52,6 +53,7 @@ export const Pane: FC = () => {
   const {t} = useTranslation();
   const dispatch = useAppDispatch();
   const selectedDefinition = useAppSelector(getSelectedDefinition);
+  const selectedDefinitionName = useAppSelector(getSelectedDefinitionName);
   const selectedDevice = useAppSelector(getSelectedConnectedDevice);
   const api = useAppSelector(getSelectedKeyboardAPI);
   const rawLayers = useAppSelector(getSelectedRawLayers);
@@ -111,7 +113,8 @@ export const Pane: FC = () => {
   };
 
   const saveLayout = async () => {
-    const {name, vendorProductId} = selectedDefinition;
+    const {vendorProductId} = selectedDefinition;
+    const name = selectedDefinitionName;
     const suggestedName =
       name.replace(/[^a-zA-Z0-9]/g, '_').toLowerCase() + '.layout.json';
     try {

--- a/src/components/panes/debug.tsx
+++ b/src/components/panes/debug.tsx
@@ -1,4 +1,5 @@
 import type {VIADefinitionV2, VIADefinitionV3} from '@the-via/reader';
+import {resolveDefinitionName} from 'src/utils/definition-name';
 import {FC, useState} from 'react';
 import {useDispatch} from 'react-redux';
 import {
@@ -214,7 +215,7 @@ export const Debug: FC = () => {
   const [showMatrix, setShowMatrix] = useState(false);
 
   const options = allDefinitions.map(([, definition], index) => ({
-    label: definition.name,
+    label: resolveDefinitionName(definition.name),
     value: `${index}`,
   }));
   const entry = allDefinitions[selectedDefinitionIndex];
@@ -355,13 +356,13 @@ export const Debug: FC = () => {
                 return (
                   <IndentedControlRow key={device.path}>
                     <SubLabel>
-                      {
+                      {resolveDefinitionName(
                         (
                           definitionEntry[1] as
                             | VIADefinitionV2
                             | VIADefinitionV3
-                        ).name
-                      }
+                        ).name,
+                      )}
                     </SubLabel>
                     <Detail>
                       0x{device.vendorProductId.toString(16).toUpperCase()}
@@ -379,7 +380,7 @@ export const Debug: FC = () => {
             </ControlRow>
             {Object.values(localDefinitions).map(([id, definition], idx) => (
               <IndentedControlRow key={idx}>
-                <SubLabel>{definition.name}</SubLabel>
+                <SubLabel>{resolveDefinitionName(definition.name)}</SubLabel>
                 <Detail>
                   0x
                   {parseInt(id).toString(16).toUpperCase()}
@@ -397,7 +398,9 @@ export const Debug: FC = () => {
                 {Object.values(remoteDefinitions).map(
                   ([id, definition], idx) => (
                     <IndentedControlRow key={idx}>
-                      <SubLabel>{definition.name}</SubLabel>
+                      <SubLabel>
+                        {resolveDefinitionName(definition.name)}
+                      </SubLabel>
                       <Detail>
                         0x
                         {parseInt(id).toString(16).toUpperCase()}

--- a/src/components/panes/design.tsx
+++ b/src/components/panes/design.tsx
@@ -20,6 +20,7 @@ import {
   VIADefinitionV3,
 } from '@the-via/reader';
 import type {DefinitionVersion} from '@the-via/reader';
+import {resolveDefinitionName} from 'src/utils/definition-name';
 import {
   ControlRow,
   Label,
@@ -250,7 +251,7 @@ export const DesignTab: FC = () => {
   );
 
   const options = versionDefinitions.map((definitionMap, index) => ({
-    label: definitionMap[definitionVersion].name,
+    label: resolveDefinitionName(definitionMap[definitionVersion].name),
     value: index.toString(),
   }));
 
@@ -410,7 +411,9 @@ export const DesignTab: FC = () => {
                 <IndentedControlRow
                   key={`${definitionVersion}-${definition[definitionVersion].vendorProductId}`}
                 >
-                  <SubLabel>{definition[definitionVersion].name}</SubLabel>
+                  <SubLabel>
+                    {resolveDefinitionName(definition[definitionVersion].name)}
+                  </SubLabel>
                   <Detail>
                     {formatNumberAsHex(
                       definition[definitionVersion].vendorProductId,

--- a/src/store/definitionNameSlice.ts
+++ b/src/store/definitionNameSlice.ts
@@ -1,0 +1,102 @@
+import {createSelector, createSlice, PayloadAction} from '@reduxjs/toolkit';
+import type {ConnectedDevice} from '../types/types';
+import {
+  isDynamicDefinitionName,
+  resolveDefinitionName,
+} from '../utils/definition-name';
+import type {AppThunk, RootState} from './index';
+import {getSelectedDefinition, getDefinitions} from './definitionsSlice';
+import {getSelectedDevicePath, getSelectedKeyboardAPI} from './devicesSlice';
+
+type DefinitionNameState = {
+  selectedOptionMap: Record<string, number>;
+};
+
+const initialState: DefinitionNameState = {
+  selectedOptionMap: {},
+};
+
+const definitionNameSlice = createSlice({
+  name: 'definitionName',
+  initialState,
+  reducers: {
+    updateDefinitionNameOption: (
+      state,
+      action: PayloadAction<{devicePath: string; selectedOption: number}>,
+    ) => {
+      const {devicePath, selectedOption} = action.payload;
+      state.selectedOptionMap[devicePath] = selectedOption;
+    },
+    clearDefinitionNameOption: (
+      state,
+      action: PayloadAction<{devicePath: string}>,
+    ) => {
+      delete state.selectedOptionMap[action.payload.devicePath];
+    },
+  },
+});
+
+export const {updateDefinitionNameOption, clearDefinitionNameOption} =
+  definitionNameSlice.actions;
+
+export default definitionNameSlice.reducer;
+
+export const getDefinitionNameOptionMap = (state: RootState) =>
+  state.definitionName.selectedOptionMap;
+
+export const getSelectedDefinitionName = createSelector(
+  getSelectedDefinition,
+  getDefinitionNameOptionMap,
+  getSelectedDevicePath,
+  (definition, selectedOptionMap, devicePath) =>
+    resolveDefinitionName(
+      definition?.name,
+      devicePath ? selectedOptionMap[devicePath] : undefined,
+    ),
+);
+
+export const getConnectedDefinitionNames = createSelector(
+  getDefinitions,
+  getDefinitionNameOptionMap,
+  (definitions, selectedOptionMap) => (device: ConnectedDevice) => {
+    const definition =
+      definitions[device.vendorProductId]?.[device.requiredDefinitionVersion];
+    return resolveDefinitionName(
+      definition?.name,
+      selectedOptionMap[device.path],
+    );
+  },
+);
+
+export const loadDefinitionName =
+  (connectedDevice: ConnectedDevice): AppThunk =>
+  async (dispatch, getState) => {
+    const state = getState();
+    const definition = getSelectedDefinition(state);
+    const api = getSelectedKeyboardAPI(state);
+    const name = definition?.name as unknown;
+
+    dispatch(clearDefinitionNameOption({devicePath: connectedDevice.path}));
+
+    if (!api || !isDynamicDefinitionName(name)) {
+      return;
+    }
+
+    const [, channelId, ...command] = name.content;
+
+    try {
+      const result = await api.getCustomMenuValue([channelId, ...command]);
+      const selectedOption = result.slice(1)[0];
+
+      if (Number.isInteger(selectedOption)) {
+        dispatch(
+          updateDefinitionNameOption({
+            devicePath: connectedDevice.path,
+            selectedOption,
+          }),
+        );
+      }
+    } catch {
+      // Dynamic names are optional. Unsupported commands use the first option.
+    }
+  };

--- a/src/store/devicesThunks.ts
+++ b/src/store/devicesThunks.ts
@@ -46,6 +46,7 @@ import {extractDeviceInfo, logAppError} from './errorsSlice';
 import {tryForgetDevice} from 'src/shims/node-hid';
 import {isAuthorizedDeviceConnected} from 'src/utils/type-predicates';
 import {loadFirmwareVersion} from './firmwareSlice';
+import {loadDefinitionName} from './definitionNameSlice';
 
 const selectConnectedDeviceRetry = createRetry(8, 100);
 
@@ -78,6 +79,7 @@ const selectConnectedDevice =
           // John you drongo, don't trust the compiler, dispatches are totes awaitable for async thunks
           await dispatch(updateLightingData(connectedDevice));
         } else if (protocol >= 11) {
+          await dispatch(loadDefinitionName(connectedDevice));
           await dispatch(loadFirmwareVersion(connectedDevice));
           // John you drongo, don't trust the compiler, dispatches are totes awaitable for async thunks
           await dispatch(updateV3MenuData(connectedDevice));

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -10,6 +10,7 @@ import designReducer from './designSlice';
 import errorsReducer from './errorsSlice';
 import {errorsListenerMiddleware} from './errorsListener';
 import firmwareReducer from './firmwareSlice';
+import definitionNameReducer from './definitionNameSlice';
 
 export const store = configureStore({
   reducer: {
@@ -23,6 +24,7 @@ export const store = configureStore({
     design: designReducer,
     errors: errorsReducer,
     firmware: firmwareReducer,
+    definitionName: definitionNameReducer,
   },
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware().prepend(errorsListenerMiddleware.middleware),

--- a/src/utils/definition-name.ts
+++ b/src/utils/definition-name.ts
@@ -1,0 +1,35 @@
+import type {DynamicDefinitionName} from '@the-via/reader';
+
+export const isDynamicDefinitionName = (
+  name: unknown,
+): name is DynamicDefinitionName => {
+  if (!name || typeof name !== 'object') {
+    return false;
+  }
+
+  const {options, content} = name as Partial<DynamicDefinitionName>;
+  return (
+    Array.isArray(options) &&
+    options.length > 0 &&
+    options.every((option) => typeof option === 'string') &&
+    Array.isArray(content) &&
+    content.length >= 3 &&
+    typeof content[0] === 'string' &&
+    content.slice(1).every((value) => typeof value === 'number')
+  );
+};
+
+export const resolveDefinitionName = (
+  name: unknown,
+  selectedOption?: number,
+): string => {
+  if (typeof name === 'string') {
+    return name;
+  }
+
+  if (!isDynamicDefinitionName(name)) {
+    return '';
+  }
+
+  return name.options[selectedOption ?? 0] ?? name.options[0];
+};

--- a/src/utils/keyboard-api.ts
+++ b/src/utils/keyboard-api.ts
@@ -185,7 +185,8 @@ type HIDAddress = string;
 type Layer = number;
 type Row = number;
 type Column = number;
-type CommandQueueArgs = [number, Array<number>] | (() => Promise<void>);
+type CommandQueueArgs =
+  [number, Array<number>, string | undefined] | (() => Promise<void>);
 type CommandQueueEntry = {
   res: (val?: any) => void;
   rej: (error?: any) => void;
@@ -412,22 +413,31 @@ export class KeyboardAPI {
     const res = await this.hidCommand(
       APICommand.CUSTOM_MENU_GET_VALUE,
       commandBytes,
+      'CUSTOM_MENU_GET_VALUE',
     );
     return res.slice(0 + commandBytes.length);
   }
 
   async setCustomMenuValue(...args: number[]): Promise<void> {
-    await this.hidCommand(APICommand.CUSTOM_MENU_SET_VALUE, args);
+    await this.hidCommand(
+      APICommand.CUSTOM_MENU_SET_VALUE,
+      args,
+      'CUSTOM_MENU_SET_VALUE',
+    );
   }
 
   async getPerKeyRGBMatrix(ledIndexMapping: number[]): Promise<number[][]> {
     const res = await Promise.all(
       ledIndexMapping.map((ledIndex) =>
-        this.hidCommand(APICommand.CUSTOM_MENU_GET_VALUE, [
-          ...PER_KEY_RGB_CHANNEL_COMMAND,
-          ledIndex,
-          1, // count
-        ]),
+        this.hidCommand(
+          APICommand.CUSTOM_MENU_GET_VALUE,
+          [
+            ...PER_KEY_RGB_CHANNEL_COMMAND,
+            ledIndex,
+            1, // count
+          ],
+          'CUSTOM_MENU_GET_VALUE',
+        ),
       ),
     );
     return res.map((r) => [...r.slice(5, 7)]);
@@ -438,13 +448,17 @@ export class KeyboardAPI {
     hue: number,
     sat: number,
   ): Promise<void> {
-    await this.hidCommand(APICommand.CUSTOM_MENU_SET_VALUE, [
-      ...PER_KEY_RGB_CHANNEL_COMMAND,
-      index,
-      1, // count
-      hue,
-      sat,
-    ]);
+    await this.hidCommand(
+      APICommand.CUSTOM_MENU_SET_VALUE,
+      [
+        ...PER_KEY_RGB_CHANNEL_COMMAND,
+        index,
+        1, // count
+        hue,
+        sat,
+      ],
+      'CUSTOM_MENU_SET_VALUE',
+    );
   }
 
   async getBacklightValue(
@@ -520,7 +534,11 @@ export class KeyboardAPI {
   }
 
   async commitCustomMenu(channel: number) {
-    await this.hidCommand(APICommand.CUSTOM_MENU_SAVE, [channel]);
+    await this.hidCommand(
+      APICommand.CUSTOM_MENU_SAVE,
+      [channel],
+      'CUSTOM_MENU_SAVE',
+    );
   }
 
   async saveLighting() {
@@ -673,12 +691,13 @@ export class KeyboardAPI {
   async hidCommand(
     command: Command,
     bytes: Array<number> = [],
+    commandName?: string,
   ): Promise<number[]> {
     return new Promise((res, rej) => {
       this.commandQueueWrapper.commandQueue.push({
         res,
         rej,
-        args: [command, bytes],
+        args: [command, bytes, commandName],
       });
       if (!this.commandQueueWrapper.isFlushing) {
         this.flushQueue();
@@ -733,7 +752,11 @@ export class KeyboardAPI {
     });
   }
 
-  async _hidCommand(command: Command, bytes: Array<number> = []): Promise<any> {
+  async _hidCommand(
+    command: Command,
+    bytes: Array<number> = [],
+    commandName?: string,
+  ): Promise<any> {
     const commandBytes = [...[COMMAND_START, command], ...bytes];
     const paddedArray = new Array(33).fill(0);
     commandBytes.forEach((val, idx) => {
@@ -754,10 +777,9 @@ export class KeyboardAPI {
       );
 
       const deviceInfo = extractDeviceInfo(this.getHID());
-      const commandName = APICommandValueToName[command];
       store.dispatch(
         logKeyboardAPIError({
-          commandName,
+          commandName: commandName ?? APICommandValueToName[command],
           commandBytes: commandBytes.slice(1),
           responseBytes: buffer,
           deviceInfo,


### PR DESCRIPTION
## Summary

Adds support for dynamically selecting the displayed board name using a value returned through the existing VIA custom-value channel.
This allows multiple hardware variants sharing the same VID/PID and definition to display different names without requiring changes to QMK core.

## Definition format

Existing static names remain supported:

```json
{
  "name": "Existing Board"
}
```

Definitions can now provide multiple names and a custom-value command:

```json
{
  "name": {
    "options": [
      "Default Board",
      "Alternate Board",
      "Special Edition"
    ],
    "content": ["id_board_variant", 0, 200]
  }
}
```

The `content` tuple uses the existing custom-control format:

```text
[token ID, custom channel ID, value ID]
```

The board returns a zero-based index corresponding to an entry in `options`.

## Behavior

- Uses the returned value to select the displayed board name.
- Falls back to the first option when the response is missing, malformed,
  unhandled, or outside the available range.
- Stores the selected option per connected device.
- Preserves existing string-based board names without behavioral changes.
- Uses the resolved name in the keyboard badge, device list, layout exports,
  debug views, and design views.

## Diagnostics

Custom-menu commands now carry their semantic command names through the HID queue.

This distinguishes overlapping protocol command IDs correctly:

- Custom-value failures display `CUSTOM_MENU_GET_VALUE`.
- Actual legacy backlight failures display `BACKLIGHT_CONFIG_GET_VALUE`.
- The same distinction is applied to custom set and save commands.

This changes diagnostic labels only; command bytes and response validation
remain unchanged.

## Dependencies

- Updates `@the-via/reader` to `1.14.2`.
- Forces the app and `via-keyboards` to share reader `1.14.2`.
- Updates `bun.lock` and `package-lock.json`.
- Removes the local reader development link and related duplicate dependency.

## Compatibility

- Existing definitions require no changes.
- Dynamic names are opt-in.
- Uses the existing VIA custom-value protocol.
- Does not require QMK-core changes.

## Verification

- `bun install --frozen-lockfile`
- `bun run build`
- `git diff --check`
