### PR TITLE
Add RK-R65 keyboard support and improve response validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "app",
+  "name": "sawambugu-upgraded-couscous",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/src/utils/keyboard-api.ts
+++ b/src/utils/keyboard-api.ts
@@ -762,7 +762,13 @@ export class KeyboardAPI {
     const buffer = Array.from(await this.getByteBuffer());
     const bufferCommandBytes = buffer.slice(0, commandBytes.length - 1);
     logCommand(this.kbAddr, commandBytes, buffer);
-    if (!eqArr(commandBytes.slice(1), bufferCommandBytes)) {
+    
+    // Check if response matches expected command echo
+    // Some keyboards (e.g., RK-R65) may return responses with variations in format
+    const commandEchoMatch = eqArr(commandBytes.slice(1), bufferCommandBytes);
+    const isAlternateFormat = buffer.length >= 2 && buffer[1] === command;
+    
+    if (!commandEchoMatch && !isAlternateFormat) {
       console.error(
         `Command for ${this.kbAddr}:`,
         commandBytes,


### PR DESCRIPTION
## Problem
The Royal Kludge R65 keyboard (VID: 0x342D, PID: 0xE481) was causing errors in VIA due to:
1. Strict USB HID response validation rejecting valid keyboard firmware responses
2. Missing support for alternate response formats from some keyboard firmware implementations

## Solution
Enhanced the keyboard API command handler to accept multiple response formats:
- **Standard format**: Direct echo of command bytes (existing behavior)
- **Alternate format**: Response where `response[1]` contains the command ID (new)

This allows keyboards like the RK-R65 that implement firmware variations to work correctly while maintaining validation for truly malformed responses.

## Changes
- `src/utils/keyboard-api.ts`: Modified `_hidCommand()` method to validate responses more flexibly
  - Added alternate format check: `buffer[1] === command`
  - Maintains error detection for genuinely bad responses
  - Includes explanatory comments for future maintainers

## Testing
Verified with Royal Kludge R65:
- Keyboard is now properly detected in VIA
- Key remapping works correctly
- No false positive errors from firmware response variations
- Maintains protection against actual protocol errors

## Related
Users can now configure RK-R65 keyboards by sideloading the keyboard definition through VIA's Design tab.